### PR TITLE
enable-system-alloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +344,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits 0.2.19",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits 0.2.19",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,12 +443,14 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.25.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
+checksum = "e902a69d09078829137b4a5d9d082e0490393537badd7c91a3d69d14639e115f"
 dependencies = [
+ "arc-swap",
  "combine",
  "itoa",
+ "num-bigint",
  "percent-encoding",
  "ryu",
  "sha1_smol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ log = "0.4"
 
 [dev-dependencies]
 anyhow = "1"
-redis = "0.25"
+redis = "0.26"
 lazy_static = "1"
 valkey-module-macros = { path = "valkeymodule-rs-macros", version = "0.1.1" }
 valkey-module = { path = "./", default-features = false, features = ["min-redis-compatibility-version-7-2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,8 +147,10 @@ bindgen = "0.69"
 cc = "1"
 
 [features]
-default = ["min-redis-compatibility-version-6-0"]
+default = ["min-redis-compatibility-version-7-0"]
 min-redis-compatibility-version-7-2 = []
 min-redis-compatibility-version-7-0 = []
 min-redis-compatibility-version-6-2 = []
 min-redis-compatibility-version-6-0 = []
+# this is used to enable System.alloc instead of ValkeyAlloc for tests
+enable-system-alloc = []

--- a/README.md
+++ b/README.md
@@ -25,5 +25,19 @@ This repo was forked from [redismodule-rs](https://github.com/RedisLabsModules/r
 
 See the [examples](examples) directory for some sample modules.
 
+To optionally enter the `System.alloc` code paths in `alloc.rs` specify this in `Cargo.toml` of your module:
+```
+[features]
+enable-system-alloc = ["valkey-module/system-alloc"]
+```
+For unit tests with `System.alloc` use this: 
+```
+cargo test --features enable-system-alloc
+```
+For integration tests with `ValkeyAlloc` use this:
+```
+cargo test
+```
+
 This crate tries to provide high-level wrappers around the standard Valkey Modules API, while preserving the API's basic concepts.
 Therefore, following the [Valkeyi Modules API](https://valkey.io/topics/modules-api-ref/) documentation will be mostly relevant here as well.


### PR DESCRIPTION
To optionally enter the `System.alloc` code paths in `alloc.rs` specify this in `Cargo.toml` of your module:

```
[features]
enable-system-alloc = ["valkey-module/system-alloc"]
```