### PR TITLE
Fix the crash with test_helper

### DIFF
--- a/examples/test_helper.rs
+++ b/examples/test_helper.rs
@@ -20,15 +20,14 @@ fn test_helper_command_name(ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyRe
     Ok(ctx.current_command_name()?.into())
 }
 
-fn test_helper_err(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
-    if args.len() < 1 {
+fn test_helper_err(_ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    if args.len() < 2 {
         return Err(ValkeyError::WrongArity);
     }
 
     let msg = args.get(1).unwrap();
 
-    ctx.reply_error_string(msg.try_as_str().unwrap());
-    Ok(().into())
+    Err(ValkeyError::Str(msg.try_as_str().unwrap()))
 }
 
 fn add_info_impl(ctx: &InfoContext, _for_crash_report: bool) -> ValkeyResult<()> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -69,8 +69,9 @@ fn test_helper_version() -> Result<()> {
         .with_context(|| "failed to run test_helper.version")?;
     assert!(res[0] > 0);
 
-    // TODO https://github.com/valkey-io/valkeymodule-rs/issues/14
     // Test also an internal implementation that might not always be reached
+    // TODO: this check is currently disabled because Valkey 8.0.0 returns
+    //       redis_version:7.2.4 and the test expects it to be 8.0.0
     // let res2: Vec<i64> = redis::cmd("test_helper._version_rm_call")
     //     .query(&mut con)
     //     .with_context(|| "failed to run test_helper._version_rm_call")?;


### PR DESCRIPTION
Related to #14.

This PR contains two commits:

1. [examples: fix test_helper.err](https://github.com/valkey-io/valkeymodule-rs/commit/fc8b63e58050ed9fb02f84f864966667af9f2667) 

`TEST_HELPER.ERR` contained two issues:

  * It checked for the wrong amount of arguments. `args.len()` acts
     like `argc` and when one expects one required argument, they should
     check for `args.len() < 2` to fail. This function had
     `args.len() < 1` which was always false
  * It replied twice to the client that made client confused. First
     reply was done via call for `ctx.reply_error_string` that is a thin
     wrapper around `ValkeyModule_ReplyWithError`. The second reply was
     with returning `ValkeyResult` from the function, which internally
     translates to another call for `ValkeyModule_ReplyWith*`. Since the
     function must return `ValkeyResult`, it was changed to reply once
     via `ValkeyResult`


2. [tests: fix the comment in tests/integration.rs](https://github.com/valkey-io/valkeymodule-rs/commit/280ce1d0c1d15ebb45f34294128501d64b7613c0) 

It used to contain a link to an issue where the certain command crashes
the valkey server, but that bug was fixed. We can't uncomment the test
yet because it tries to compare `valkey_version` with `redis_version`
which are not guaranteed to be the same.