### PR TITLE
feat(digest): Digest wrappers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,10 @@ name = "data_type"
 crate-type = ["cdylib"]
 
 [[example]]
+name = "data_type2"
+crate-type = ["cdylib"]
+
+[[example]]
 name = "load_unload"
 crate-type = ["cdylib"]
 

--- a/examples/data_type.rs
+++ b/examples/data_type.rs
@@ -19,8 +19,6 @@ static MY_VALKEY_TYPE: ValkeyType = ValkeyType::new(
         aof_rewrite: None,
         free: Some(free),
         digest: Some(digest),
-
-        // Currently unused by Redis
         mem_usage: None,
 
         // Aux data

--- a/examples/data_type2.rs
+++ b/examples/data_type2.rs
@@ -23,8 +23,6 @@ static MY_VALKEY_TYPE: ValkeyType = ValkeyType::new(
         aof_rewrite: None,
         free: Some(free),
         digest: Some(digest),
-
-        // Currently unused by Redis
         mem_usage: None,
 
         // Aux data

--- a/examples/data_type2.rs
+++ b/examples/data_type2.rs
@@ -1,0 +1,107 @@
+use raw::KeyType;
+use std::collections::HashMap;
+use std::os::raw::c_void;
+use std::ptr::null;
+use valkey_module::alloc::ValkeyAlloc;
+use valkey_module::digest::Digest;
+use valkey_module::key::{ValkeyKey, ValkeyKeyWritable};
+use valkey_module::native_types::ValkeyType;
+use valkey_module::{raw, valkey_module, Context, NextArg, ValkeyResult, ValkeyString};
+
+#[derive(Debug)]
+struct MyType {
+    data: i64,
+}
+
+static MY_VALKEY_TYPE: ValkeyType = ValkeyType::new(
+    "mytype123",
+    0,
+    raw::RedisModuleTypeMethods {
+        version: raw::REDISMODULE_TYPE_METHOD_VERSION as u64,
+        rdb_load: None,
+        rdb_save: None,
+        aof_rewrite: None,
+        free: Some(free),
+        digest: Some(digest),
+
+        // Currently unused by Redis
+        mem_usage: None,
+
+        // Aux data
+        aux_load: None,
+        aux_save: None,
+        aux_save2: None,
+        aux_save_triggers: 0,
+
+        free_effort: None,
+        unlink: None,
+        copy: None,
+        defrag: None,
+
+        copy2: None,
+        free_effort2: None,
+        mem_usage2: None,
+        unlink2: None,
+    },
+);
+
+unsafe extern "C" fn free(value: *mut c_void) {
+    drop(Box::from_raw(value.cast::<MyType>()));
+}
+
+unsafe extern "C" fn digest(md: *mut raw::RedisModuleDigest, value: *mut c_void) {
+    let mut dig = Digest::new(md);
+    let val = &*(value.cast::<MyType>());
+    dig.add_long_long(val.data);
+    dig.get_db_id();
+    let keyname = dig.get_key_name();
+    assert!(!keyname.is_empty());
+    dig.end_sequence();
+}
+
+fn alloc_set(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    let mut args = args.into_iter().skip(1);
+    let key = args.next_arg()?;
+    let size = args.next_i64()?;
+
+    ctx.log_debug(format!("key: {key}, size: {size}").as_str());
+
+    let key = ctx.open_key_writable(&key);
+
+    if let Some(value) = key.get_value::<MyType>(&MY_VALKEY_TYPE)? {
+        value.data = size;
+    } else {
+        let value = MyType { data: size };
+        key.set_value(&MY_VALKEY_TYPE, value)?;
+    }
+    Ok(size.into())
+}
+
+fn alloc_get(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    let mut args = args.into_iter().skip(1);
+    let key = args.next_arg()?;
+
+    let key = ctx.open_key(&key);
+
+    let value = match key.get_value::<MyType>(&MY_VALKEY_TYPE)? {
+        Some(value) => value.data.into(),
+        None => ().into(),
+    };
+
+    Ok(value)
+}
+
+//////////////////////////////////////////////////////
+
+valkey_module! {
+    name: "alloc2",
+    version: 1,
+    allocator: (ValkeyAlloc, ValkeyAlloc),
+    data_types: [
+        MY_VALKEY_TYPE,
+    ],
+    commands: [
+        ["alloc.set", alloc_set, "write", 1, 1, 1],
+        ["alloc.get", alloc_get, "readonly", 1, 1, 1],
+    ],
+}

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,0 +1,23 @@
+use crate::raw;
+use std::os::raw::{c_int};
+
+/// `Digest` is a high-level rust interface to the Valkey module C API 
+/// abstracting away the raw C ffi calls.
+pub struct Digest {
+    pub dig: *mut raw::RedisModuleDigest,
+}
+
+impl Digest {
+    pub const fn new(dig: *mut raw::RedisModuleDigest) -> Self {
+        Self { dig }
+    }
+
+    pub fn key_name(&self) -> *mut raw::RedisModuleString {
+        unsafe { (*self.dig).key }
+    }
+
+    pub fn db_id(&self) -> c_int {
+        unsafe { (*self.dig).dbid }
+    }
+}
+

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,4 +1,5 @@
-use crate::raw;
+use crate::{raw, ValkeyString};
+
 use std::os::raw::c_char;
 
 /// `Digest` is a high-level rust interface to the Valkey module C API
@@ -17,56 +18,51 @@ impl Digest {
     /// # Panics
     ///
     /// Will panic if `RedisModule_GetKeyNameFromDigest` is missing in redismodule.h
-    pub fn get_key_name(&self) -> *const raw::RedisModuleString {
-        unsafe {
-            match raw::RedisModule_GetKeyNameFromDigest {
-                Some(get_key_name_from_digest) => get_key_name_from_digest(self.dig),
-                None => panic!("RedisModule_GetKeyNameFromDigest is not available."),
-            }
-        }
+    pub fn get_key_name(&self) -> ValkeyString {
+        ValkeyString::from_redis_module_string(std::ptr::null_mut(), unsafe {
+            raw::RedisModule_GetKeyNameFromDigest
+                .expect("RedisModule_GetKeyNameFromDigest is not available.")(self.dig)
+            .cast_mut()
+        })
     }
 
-    /// Returns the database id of this [`Digest`].
+    /// Returns the database ID of this [`Digest`].
     ///
     /// # Panics
     ///
     /// Will panic if `RedisModule_GetDbIdFromDigest` is missing in redismodule.h
     pub fn get_db_id(&self) -> i32 {
         unsafe {
-            match raw::RedisModule_GetDbIdFromDigest {
-                Some(get_db_id_from_digest) => get_db_id_from_digest(self.dig),
-                None => panic!("RedisModule_GetDbIdFromDigest is not available."),
-            }
+            raw::RedisModule_GetDbIdFromDigest
+                .expect("RedisModule_GetDbIdFromDigest is not available.")(self.dig)
         }
     }
 
-    /// Converts the long long input to a string and adds it to this [`Digest`].
-    ///
-    /// # Panics
-    ///
-    /// Will panic if `RedisModule_DigestAddLongLong` is missing in redismodule.h
-    pub fn add_long_long(&mut self, ll: i64) {
-        unsafe {
-            match raw::RedisModule_DigestAddLongLong {
-                Some(digest_add_long_long) => digest_add_long_long(self.dig, ll),
-                None => panic!("RedisModule_DigestAddLongLong is not available."),
-            }
-        }
-    }
-
-    /// Add a new element to this [`Digest`].
+    /// Adds a new element to this [`Digest`].
     ///
     /// # Panics
     ///
     /// Will panic if `RedisModule_DigestAddStringBuffer` is missing in redismodule.h
     pub fn add_string_buffer(&mut self, ele: &[u8]) {
         unsafe {
-            match raw::RedisModule_DigestAddStringBuffer {
-                Some(digest_add_string_buffer) => {
-                    digest_add_string_buffer(self.dig, ele.as_ptr().cast::<c_char>(), ele.len())
-                }
-                None => panic!("RedisModule_DigestAddStringBuffer is not available."),
-            }
+            raw::RedisModule_DigestAddStringBuffer
+                .expect("RedisModule_DigestAddStringBuffer is not available.")(
+                self.dig,
+                ele.as_ptr().cast::<c_char>(),
+                ele.len(),
+            )
+        }
+    }
+
+    /// Similar to [`Digest::add_string_buffer`], but takes [`i64`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `RedisModule_DigestAddLongLong` is missing in redismodule.h
+    pub fn add_long_long(&mut self, ll: i64) {
+        unsafe {
+            raw::RedisModule_DigestAddLongLong
+                .expect("RedisModule_DigestAddLongLong is not available.")(self.dig, ll)
         }
     }
 
@@ -77,10 +73,8 @@ impl Digest {
     /// Will panic if `RedisModule_DigestEndSequence` is missing in redismodule.h
     pub fn end_sequence(&mut self) {
         unsafe {
-            match raw::RedisModule_DigestEndSequence {
-                Some(digest_end_sequence) => digest_end_sequence(self.dig),
-                None => panic!("RedisModule_DigestEndSequence is not available."),
-            }
+            raw::RedisModule_DigestEndSequence
+                .expect("RedisModule_DigestEndSequence is not available.")(self.dig)
         }
     }
 }

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,7 +1,7 @@
 use crate::raw;
-use std::os::raw::{c_int};
+use std::os::raw::c_char;
 
-/// `Digest` is a high-level rust interface to the Valkey module C API 
+/// `Digest` is a high-level rust interface to the Valkey module C API
 /// abstracting away the raw C ffi calls.
 pub struct Digest {
     pub dig: *mut raw::RedisModuleDigest,
@@ -12,12 +12,75 @@ impl Digest {
         Self { dig }
     }
 
-    pub fn key_name(&self) -> *mut raw::RedisModuleString {
-        unsafe { (*self.dig).key }
+    /// Returns the key name of this [`Digest`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `RedisModule_GetKeyNameFromDigest` is missing in redismodule.h
+    pub fn get_key_name(&self) -> *const raw::RedisModuleString {
+        unsafe {
+            match raw::RedisModule_GetKeyNameFromDigest {
+                Some(get_key_name_from_digest) => get_key_name_from_digest(self.dig),
+                None => panic!("RedisModule_GetKeyNameFromDigest is not available."),
+            }
+        }
     }
 
-    pub fn db_id(&self) -> c_int {
-        unsafe { (*self.dig).dbid }
+    /// Returns the database id of this [`Digest`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `RedisModule_GetDbIdFromDigest` is missing in redismodule.h
+    pub fn get_db_id(&self) -> i32 {
+        unsafe {
+            match raw::RedisModule_GetDbIdFromDigest {
+                Some(get_db_id_from_digest) => get_db_id_from_digest(self.dig),
+                None => panic!("RedisModule_GetDbIdFromDigest is not available."),
+            }
+        }
+    }
+
+    /// Converts the long long input to a string and adds it to this [`Digest`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `RedisModule_DigestAddLongLong` is missing in redismodule.h
+    pub fn add_long_long(&mut self, ll: i64) {
+        unsafe {
+            match raw::RedisModule_DigestAddLongLong {
+                Some(digest_add_long_long) => digest_add_long_long(self.dig, ll),
+                None => panic!("RedisModule_DigestAddLongLong is not available."),
+            }
+        }
+    }
+
+    /// Add a new element to this [`Digest`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `RedisModule_DigestAddStringBuffer` is missing in redismodule.h
+    pub fn add_string_buffer(&mut self, ele: &[u8]) {
+        unsafe {
+            match raw::RedisModule_DigestAddStringBuffer {
+                Some(digest_add_string_buffer) => {
+                    digest_add_string_buffer(self.dig, ele.as_ptr().cast::<c_char>(), ele.len())
+                }
+                None => panic!("RedisModule_DigestAddStringBuffer is not available."),
+            }
+        }
+    }
+
+    /// Ends the current sequence in this [`Digest`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `RedisModule_DigestEndSequence` is missing in redismodule.h
+    pub fn end_sequence(&mut self) {
+        unsafe {
+            match raw::RedisModule_DigestEndSequence {
+                Some(digest_end_sequence) => digest_end_sequence(self.dig),
+                None => panic!("RedisModule_DigestEndSequence is not available."),
+            }
+        }
     }
 }
-

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,6 +1,6 @@
 use crate::{raw, ValkeyString};
 
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_int, c_longlong};
 
 /// `Digest` is a high-level rust interface to the Valkey module C API
 /// abstracting away the raw C ffi calls.
@@ -31,7 +31,7 @@ impl Digest {
     /// # Panics
     ///
     /// Will panic if `RedisModule_GetDbIdFromDigest` is missing in redismodule.h
-    pub fn get_db_id(&self) -> i32 {
+    pub fn get_db_id(&self) -> c_int {
         unsafe {
             raw::RedisModule_GetDbIdFromDigest
                 .expect("RedisModule_GetDbIdFromDigest is not available.")(self.dig)
@@ -59,7 +59,7 @@ impl Digest {
     /// # Panics
     ///
     /// Will panic if `RedisModule_DigestAddLongLong` is missing in redismodule.h
-    pub fn add_long_long(&mut self, ll: i64) {
+    pub fn add_long_long(&mut self, ll: c_longlong) {
         unsafe {
             raw::RedisModule_DigestAddLongLong
                 .expect("RedisModule_DigestAddLongLong is not available.")(self.dig, ll)

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -19,7 +19,7 @@ impl Digest {
     ///
     /// Will panic if `RedisModule_GetKeyNameFromDigest` is missing in redismodule.h
     pub fn get_key_name(&self) -> ValkeyString {
-        ValkeyString::from_redis_module_string(std::ptr::null_mut(), unsafe {
+        ValkeyString::new(None, unsafe {
             raw::RedisModule_GetKeyNameFromDigest
                 .expect("RedisModule_GetKeyNameFromDigest is not available.")(self.dig)
             .cast_mut()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate num_traits;
 
 pub mod alloc;
 pub mod apierror;
+pub mod digest;
 pub mod error;
 pub mod native_types;
 pub mod raw;
@@ -11,7 +12,6 @@ mod redismodule;
 pub mod redisraw;
 pub mod redisvalue;
 pub mod stream;
-pub mod digest;
 
 pub mod configuration;
 mod context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod redismodule;
 pub mod redisraw;
 pub mod redisvalue;
 pub mod stream;
+pub mod digest;
 
 pub mod configuration;
 mod context;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -739,7 +739,7 @@ fn test_expire() -> Result<()> {
 
 #[test]
 fn test_alloc() -> Result<()> {
-    let port: u16 = 6503;
+    let port: u16 = 6509;
     let _guards = vec![start_valkey_server_with_module("data_type", port)
         .with_context(|| FAILED_TO_START_SERVER)?];
     let mut con = get_valkey_connection(port).with_context(|| FAILED_TO_CONNECT_TO_SERVER)?;
@@ -830,6 +830,107 @@ fn test_debug() -> Result<()> {
         .query(&mut con)
         .with_context(|| "failed to run DEBUG DIGEST")?;
     assert_eq!(res, "0".repeat(40));
+
+    Ok(())
+}
+
+#[test]
+fn test_debug2() -> Result<()> {
+    // DB1
+    let port: u16 = 6505;
+    let _guards = vec![start_valkey_server_with_module("data_type2", port)
+        .with_context(|| FAILED_TO_START_SERVER)?];
+    let mut con1 = get_valkey_connection(port).with_context(|| FAILED_TO_CONNECT_TO_SERVER)?;
+
+    // DB2
+    let port2: u16 = 6506;
+    let _guards = vec![start_valkey_server_with_module("data_type2", port2)
+        .with_context(|| FAILED_TO_START_SERVER)?];
+    let mut con2 = get_valkey_connection(port2).with_context(|| FAILED_TO_CONNECT_TO_SERVER)?;
+
+    // Set on DB1
+    let _: i64 = redis::cmd("alloc.set")
+        .arg(&["k1", "3"])
+        .query(&mut con1)
+        .with_context(|| "failed to run alloc.set")?;
+
+    // Test DEBUG DIGEST command on DB1 to verify digest callback
+    let res: String = redis::cmd("DEBUG")
+        .arg("digest")
+        .query(&mut con1)
+        .with_context(|| "failed to run DEBUG DIGEST")?;
+    assert!(
+        !res.is_empty(),
+        "DEBUG DIGEST should return a non-empty string"
+    );
+
+    // Get on DB1
+    let get_res_db1: String = redis::cmd("alloc.get")
+        .arg("k1")
+        .query(&mut con1)
+        .with_context(|| "failed to run DEBUG DIGEST")?;
+    assert!(
+        !get_res_db1.is_empty(),
+        "alloc.get should return a non-empty string"
+    );
+
+    // Set on DB2
+    let _: i64 = redis::cmd("alloc.set")
+        .arg(&["k1", "3"])
+        .query(&mut con2)
+        .with_context(|| "failed to run alloc.set")?;
+
+    // Test DEBUG DIGEST command on DB2 to verify digest callback
+    let res: String = redis::cmd("DEBUG")
+        .arg("digest")
+        .query(&mut con2)
+        .with_context(|| "failed to run DEBUG DIGEST")?;
+    assert!(
+        !res.is_empty(),
+        "DEBUG DIGEST should return a non-empty string"
+    );
+
+    // Get on DB2
+    let get_res_db2: String = redis::cmd("alloc.get")
+        .arg("k1")
+        .query(&mut con2)
+        .with_context(|| "failed to run DEBUG DIGEST")?;
+    assert!(
+        !get_res_db2.is_empty(),
+        "DEBUG DIGEST should return a non-empty string"
+    );
+
+    // Compare digested DB1 & DB2
+    assert_eq!(get_res_db1, get_res_db2);
+
+    // Delete key on DB1
+    let _: i64 = redis::cmd("DEL")
+        .arg("k1")
+        .query(&mut con1)
+        .with_context(|| "failed to run DEL")?;
+
+    // Test DEBUG DIGEST on DB1 to verify digest callback on unset key
+    let res_db1: String = redis::cmd("DEBUG")
+        .arg("digest")
+        .query(&mut con1)
+        .with_context(|| "failed to run DEBUG DIGEST")?;
+    assert_eq!(res_db1, "0".repeat(40));
+
+    // Delete key on DB2
+    let _: i64 = redis::cmd("DEL")
+        .arg("k1")
+        .query(&mut con2)
+        .with_context(|| "failed to run DEL")?;
+
+    // Test DEBUG DIGEST command on DB2 to verify digest callback on unset key
+    let res_db2: String = redis::cmd("DEBUG")
+        .arg("digest")
+        .query(&mut con2)
+        .with_context(|| "failed to run DEBUG DIGEST")?;
+    assert_eq!(res_db2, "0".repeat(40));
+
+    // Compare empty DB1 & DB2
+    assert_eq!(res_db1, res_db2);
 
     Ok(())
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -813,7 +813,7 @@ fn test_debug() -> Result<()> {
     let res: redis::Value = redis::cmd("DEBUG")
         .arg(&["digest-value", "test_key"])
         .query(&mut con)
-        .with_context(|| "failed to run DEBUG DIGEST")?;
+        .with_context(|| "failed to run DEBUG DIGEST-VALUE")?;
     assert!(!matches!(res, redis::Value::Nil), "DEBUG DIGEST-VALUE should not return nil");
 
     let _: i64 = redis::cmd("DEL")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -799,9 +799,9 @@ fn test_debug() -> Result<()> {
         .query(&mut con)
         .with_context(|| "failed to run alloc.set")?;
 
-    // Test DEBUG digest command to verify digest callback
+    // Test DEBUG DIGEST command to verify digest callback
     let res: String = redis::cmd("DEBUG")
-        .arg(&["digest"])
+        .arg("digest")
         .query(&mut con)
         .with_context(|| "failed to run DEBUG DIGEST")?;
     assert!(
@@ -809,19 +809,26 @@ fn test_debug() -> Result<()> {
         "DEBUG DIGEST should return a non-empty string"
     );
 
+    // Test DEBUG DIGEST-VALUE command to verify digest callback
+    let res: redis::Value = redis::cmd("DEBUG")
+        .arg(&["digest-value", "test_key"])
+        .query(&mut con)
+        .with_context(|| "failed to run DEBUG DIGEST")?;
+    assert!(!matches!(res, redis::Value::Nil), "DEBUG DIGEST-VALUE should not return nil");
+
     let _: i64 = redis::cmd("DEL")
-        .arg(&["test_key"])
+        .arg("test_key")
         .query(&mut con)
         .with_context(|| "failed to run DEL")?;
 
     // Test DEBUG digest command to verify digest callback on unset key
     let res: String = redis::cmd("DEBUG")
-        .arg(&["digest"])
+        .arg("digest")
         .query(&mut con)
         .with_context(|| "failed to run DEBUG DIGEST")?;
-    assert!(
-        !res.is_empty(),
-        "DEBUG DIGEST should return a non-empty string"
+    assert_eq!(
+        res,
+        "0".repeat(40)
     );
 
     Ok(())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -738,7 +738,7 @@ fn test_expire() -> Result<()> {
 }
 
 #[test]
-fn test_alloc_data_type() -> Result<()> {
+fn test_alloc() -> Result<()> {
     let port: u16 = 6503;
     let _guards = vec![start_valkey_server_with_module("data_type", port)
         .with_context(|| FAILED_TO_START_SERVER)?];

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -831,11 +831,8 @@ fn test_debug() -> Result<()> {
         .with_context(|| "failed to run DEBUG DIGEST")?;
     assert_eq!(res, "0".repeat(40));
 
-    Ok(())
-}
+    // Start testing add_long_long
 
-#[test]
-fn test_debug2() -> Result<()> {
     // DB1
     let port: u16 = 6505;
     let _guards = vec![start_valkey_server_with_module("data_type2", port)


### PR DESCRIPTION
Adds rust wrappers for module APIs `ValkeyModule_DigestAddStringBuffer`, `ValkeyModule_DigestAddLongLong`, `ValkeyModule_DigestEndSequence`, `ValkeyModule_GetKeyNameFromDigest`, `ValkeyModule_GetDbIdFromDigest`

Adds callback for `digest` and integration test for `alloc` module

Closes #97 