### PR TITLE
Adding capabilty for creating custom ACL categories as well as setting custom and existing ACL categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ crate-type = ["cdylib"]
 [[example]]
 name = "acl"
 crate-type = ["cdylib"]
+required-features = ["min-valkey-compatibility-version-8-0"]
 
 [[example]]
 name = "call"
@@ -140,7 +141,7 @@ anyhow = "1"
 redis = "0.27"
 lazy_static = "1"
 valkey-module-macros = { path = "valkeymodule-rs-macros", version = "0.1.1" }
-valkey-module = { path = "./", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
+valkey-module = { path = "./", default-features = false, features = ["min-valkey-compatibility-version-8-0", "min-redis-compatibility-version-7-2"] }
 
 [build-dependencies]
 bindgen = "0.70"
@@ -148,6 +149,7 @@ cc = "1"
 
 [features]
 default = ["min-redis-compatibility-version-7-0"]
+min-valkey-compatibility-version-8-0 = []
 min-redis-compatibility-version-7-2 = []
 min-redis-compatibility-version-7-0 = []
 min-redis-compatibility-version-6-2 = []

--- a/examples/acl.rs
+++ b/examples/acl.rs
@@ -1,7 +1,7 @@
 use valkey_module::alloc::ValkeyAlloc;
 use valkey_module::{
     valkey_module, AclPermissions, Context, NextArg, ValkeyError, ValkeyResult, ValkeyString,
-    ValkeyValue,
+    ValkeyValue, VALKEY_OK,
 };
 
 fn verify_key_access_for_user(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
@@ -19,6 +19,16 @@ fn get_current_user(ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
     Ok(ValkeyValue::BulkValkeyString(ctx.get_current_user()))
 }
 
+fn custom_category(_ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
+    VALKEY_OK
+}
+fn custom_categories(_ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
+    VALKEY_OK
+}
+fn existing_categories(_ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
+    VALKEY_OK
+}
+
 //////////////////////////////////////////////////////
 
 valkey_module! {
@@ -26,8 +36,15 @@ valkey_module! {
     version: 1,
     allocator: (ValkeyAlloc, ValkeyAlloc),
     data_types: [],
+    acl_categories: [
+        "custom_acl_one",
+        "custom_acl_two"
+    ]
     commands: [
         ["verify_key_access_for_user", verify_key_access_for_user, "", 0, 0, 0],
         ["get_current_user", get_current_user, "", 0, 0, 0],
+        ["custom_category", custom_category, "write",  0, 0, 0, "custom_acl_one"],
+        ["custom_categories", custom_categories, "", 0, 0, 0, "custom_acl_one custom_acl_two"],
+        ["existing_categories", existing_categories, "write", 0, 0, 0, "read fast admin"],
     ],
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -13,7 +13,6 @@ fn hello_mul(_: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
         .collect::<Result<Vec<i64>, ValkeyError>>()?;
 
     let product = nums.iter().product();
-
     let mut response = nums;
     response.push(product);
 

--- a/src/context/commands.rs
+++ b/src/context/commands.rs
@@ -464,6 +464,7 @@ api! {[
 
 #[cfg(all(
     any(
+        feature = "min-valkey-compatibility-version-8-0",
         feature = "min-redis-compatibility-version-7-2",
         feature = "min-redis-compatibility-version-7-0"
     ),
@@ -488,6 +489,7 @@ pub fn register_commands(ctx: &Context) -> Status {
         feature = "min-redis-compatibility-version-6-0"
     ),
     not(any(
+        feature = "min-valkey-compatibility-version-8-0",
         feature = "min-redis-compatibility-version-7-2",
         feature = "min-redis-compatibility-version-7-0"
     ))

--- a/src/include/redismodule.h
+++ b/src/include/redismodule.h
@@ -969,6 +969,7 @@ REDISMODULE_API RedisModuleCommand *(*RedisModule_GetCommand)(RedisModuleCtx *ct
 REDISMODULE_API int (*RedisModule_CreateSubcommand)(RedisModuleCommand *parent, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetCommandInfo)(RedisModuleCommand *command, const RedisModuleCommandInfo *info) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_SetCommandACLCategories)(RedisModuleCommand *command, const char *ctgrsflags) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_AddACLCategory)(RedisModuleCtx *ctx, const char *name) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetModuleAttribs)(RedisModuleCtx *ctx, const char *name, int ver, int apiver) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsModuleNameBusy)(const char *name) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_WrongArity)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -1323,6 +1324,7 @@ static void RedisModule_InitAPI(RedisModuleCtx *ctx) {
     REDISMODULE_GET_API(GetCommand);
     REDISMODULE_GET_API(CreateSubcommand);
     REDISMODULE_GET_API(SetCommandInfo);
+    REDISMODULE_GET_API(AddACLCategory);
     REDISMODULE_GET_API(SetCommandACLCategories);
     REDISMODULE_GET_API(SetModuleAttribs);
     REDISMODULE_GET_API(IsModuleNameBusy);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,10 @@ pub use crate::context::commands;
 pub use crate::context::keys_cursor::KeysCursor;
 pub use crate::context::server_events;
 pub use crate::context::AclPermissions;
-#[cfg(feature = "min-redis-compatibility-version-7-2")]
+#[cfg(all(any(
+    feature = "min-valkey-compatibility-version-8-0",
+    feature = "min-redis-compatibility-version-7-2"
+)))]
 pub use crate::context::BlockingCallOptions;
 pub use crate::context::CallOptionResp;
 pub use crate::context::CallOptions;

--- a/valkeymodule-rs-macros-internals/src/api_versions.rs
+++ b/valkeymodule-rs-macros-internals/src/api_versions.rs
@@ -21,7 +21,7 @@ lazy_static::lazy_static! {
         ("RedisModule_ACLAddLogEntryByUserName".to_string(), 70200),
         ("RedisModule_GetCommand".to_string(), 70000),
         ("RedisModule_SetCommandInfo".to_string(), 70000),
-
+        ("RedisModule_AddACLCategory".to_string(), 80000),
     ]);
 
     pub(crate) static ref API_OLDEST_VERSION: usize = 60000;
@@ -30,6 +30,7 @@ lazy_static::lazy_static! {
         (60200, "min-redis-compatibility-version-6-2".to_string()),
         (70000, "min-redis-compatibility-version-7-0".to_string()),
         (70200, "min-redis-compatibility-version-7-2".to_string()),
+        (80000, "min-valkey-compatibility-version-8-0".to_string()),
     ];
 }
 

--- a/valkeymodule-rs-macros/src/valkey_value.rs
+++ b/valkeymodule-rs-macros/src/valkey_value.rs
@@ -141,8 +141,6 @@ pub fn valkey_value(item: TokenStream) -> TokenStream {
     match struct_input.data {
         Data::Struct(s) => struct_valkey_value(struct_name, s),
         Data::Enum(e) => enum_valkey_value(struct_name, e),
-        _ => {
-            quote! {compile_error!("ValkeyValue derive can only be apply on struct.")}.into()
-        }
+        _ => quote! {compile_error!("ValkeyValue derive can only be apply on struct.")}.into(),
     }
 }


### PR DESCRIPTION
### Overview
This pr is in relation to issue #96.
 
This is designed to allow the capability of creating and setting custom ACL categories. This also allows setting existing ACL categories to commands. 
This is not a breaking change as all fields that have been created in the macros are optional which means that developers will only need to add the field at the end of the commands if they want to add acl categories and can leave it as it was if they don't.
### Testing
Tested by amending ACL example. This involved creating three new commands with the sole purpose of assigning ACL categories to them.
In the setup we define two new custom ACL categories called custom_acl_one and custom_acl_two. The next important part is that in the command definition in the valkey_module macro we assign the desired ACL's to the commands. We test that these ACL's are assigned correctly by adding a new test in integration.rs where we get the list of commands associated with the ACL's and determine if the new commands show up correctly.
