### PR TITLE
Support Calloc by implementing alloc_zeroed on the Global Alloc (ValkeyAlloc) of valkeymodule-rs

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -41,8 +41,8 @@ unsafe impl GlobalAlloc for ValkeyAlloc {
         if cfg!(feature = "enable-system-alloc") {
             return std::alloc::System.alloc(layout);
         }
-        let size = (layout.size() + layout.align() - 1) & (!(layout.align() - 1));
 
+        let size = (layout.size() + layout.align() - 1) & (!(layout.align() - 1));
         match raw::RedisModule_Alloc {
             Some(alloc) => alloc(size).cast(),
             None => allocation_free_panic(VALKEY_ALLOCATOR_NOT_AVAILABLE_MESSAGE),
@@ -65,9 +65,9 @@ unsafe impl GlobalAlloc for ValkeyAlloc {
             return std::alloc::System.alloc_zeroed(layout);
         }
         let size = (layout.size() + layout.align() - 1) & (!(layout.align() - 1));
-
+        let num_elements = size / layout.align();
         match raw::RedisModule_Calloc {
-            Some(calloc) => calloc(size, 1).cast(),
+            Some(calloc) => calloc(num_elements, layout.align()).cast(),
             None => allocation_free_panic(VALKEY_ALLOCATOR_NOT_AVAILABLE_MESSAGE),
         }
     }


### PR DESCRIPTION
Support Calloc by implementing `alloc_zeroed` on the Global Alloc (`ValkeyAlloc`) of valkeymodule-rs.

`alloc_zeroed` is used as an optimization (and also serves specific use cases) used by other libraries in Rust. It is particularly useful when creating large vectors to avoid a large allocation at the time of creation of the object. It improves the performance of these operations because the memory requested is allocated lazily. 

Without this change, `alloc_zeroed` AND `alloc` would be handled by the SDK using `alloc` (which uses `ValkeyModule_Alloc`) because only the `alloc` and `dealloc` functions were implemented on `ValkeyAlloc`.

With this change, any `alloc_zeroed` will be handled by the SDK using `ValkeyModule_Calloc`. Any `alloc` will be handled using `ValkeyModule_Alloc`.

In our testing (valkey-bloom), this optimization brought down the valkey server side latency (`INFO commandstats`) for creations of large Bloom filter objects of 1M capacity from ~500 usec to ~20 usec, and for objects of 10M capacity from 5 milliseconds to 40 usec. With this change, similar gains can also be expected for large object creation of other datatypes  when `alloc_zeroed` is used.

For a good summary, you can see: https://blogs.fau.de/hager/archives/825



