### PR TITLE
Use VM_Init by default and RM_Init only via a new feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,3 +160,5 @@ min-redis-compatibility-version-6-2 = []
 min-redis-compatibility-version-6-0 = []
 # this is used to enable System.alloc instead of ValkeyAlloc for tests
 enable-system-alloc = []
+# this is to indicate the Module wants to use RedisModule APIs for calls
+use-redismodule-api = []

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ This repo was forked from [redismodule-rs](https://github.com/RedisLabsModules/r
 
 See the [examples](examples) directory for some sample modules.
 
+This crate tries to provide high-level wrappers around the standard Valkey Modules API, while preserving the API's basic concepts.
+Therefore, following the [Valkey Modules API](https://valkey.io/topics/modules-api-ref/) documentation will be mostly relevant here as well.
+
+## Feature Flags
+
+1. System Allocator
+
+This feature flag is ideal for unit testing where the engine server is not running, and we do not have access to the Vakey engine Allocator; so we can use the System Allocator instead.
 To optionally enter the `System.alloc` code paths in `alloc.rs` specify this in `Cargo.toml` of your module:
 ```
 [features]
@@ -39,5 +47,17 @@ For integration tests with `ValkeyAlloc` use this:
 cargo test
 ```
 
-This crate tries to provide high-level wrappers around the standard Valkey Modules API, while preserving the API's basic concepts.
-Therefore, following the [Valkeyi Modules API](https://valkey.io/topics/modules-api-ref/) documentation will be mostly relevant here as well.
+2. Redis Compatibility
+
+This feature flag is useful in case you have a Module that needs to be loaded on both Valkey and Redis Servers. In this case, you can use the `use-redismodule-api` flag so that the Module is loaded using the RedisModule API Initialization for compatibility.
+
+To use this feature by conditionally, specify the following in your `Cargo.toml`:
+```
+[features]
+use-redismodule-api = ["valkey-module/use-redismodule-api"]
+default = []
+```
+
+```
+cargo build --release --features use-redismodule-api
+```

--- a/build.rs
+++ b/build.rs
@@ -61,10 +61,15 @@ fn main() {
 
     build
         .define(RM_EXPERIMENTAL_API, None)
-        .define(VM_EXPERIMENTAL_API, None)
         .file("src/redismodule.c")
         .include("src/include/")
         .compile("redismodule");
+
+    build
+        .define(VM_EXPERIMENTAL_API, None)
+        .file("src/valkeymodule.c")
+        .include("src/include/")
+        .compile("valkeymodule");
 
     let bindings_generator = bindgen::Builder::default();
 

--- a/src/include/valkeymodule.h
+++ b/src/include/valkeymodule.h
@@ -1881,7 +1881,7 @@ VALKEYMODULE_API ValkeyModuleScriptingEngineExecutionState (*ValkeyModule_GetFun
 
 /* This is included inline inside each Valkey module. */
 static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, int apiver) VALKEYMODULE_ATTR_UNUSED;
-static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, int apiver) {
+static void ValkeyModule_InitAPI(ValkeyModuleCtx *ctx) {
     void *getapifuncptr = ((void **)ctx)[0];
     ValkeyModule_GetApi = (int (*)(const char *, void *))(unsigned long)getapifuncptr;
     VALKEYMODULE_GET_API(Alloc);
@@ -2248,7 +2248,10 @@ static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, in
     VALKEYMODULE_GET_API(RegisterScriptingEngine);
     VALKEYMODULE_GET_API(UnregisterScriptingEngine);
     VALKEYMODULE_GET_API(GetFunctionExecutionState);
+}
 
+static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, int apiver) {
+    ValkeyModule_InitAPI(ctx);
     if (ValkeyModule_IsModuleNameBusy && ValkeyModule_IsModuleNameBusy(name)) return VALKEYMODULE_ERR;
     ValkeyModule_SetModuleAttribs(ctx, name, ver, apiver);
     return VALKEYMODULE_OK;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,8 +108,15 @@ pub fn basic_info_command_handler(ctx: &InfoContext, for_crash_report: bool) {
 }
 
 /// Initialize RedisModuleAPI without register as a module.
+#[cfg(feature = "use-redismodule-api")]
 pub fn init_api(ctx: &Context) {
     unsafe { crate::raw::Export_RedisModule_InitAPI(ctx.ctx) };
+}
+
+/// Initialize ValkeyModuleAPI without register as a module.
+#[cfg(not(feature = "use-redismodule-api"))]
+pub fn init_api(ctx: &Context) {
+    unsafe { crate::raw::Export_ValkeyModule_InitAPI(ctx.ctx as *mut raw::ValkeyModuleCtx) };
 }
 
 pub(crate) unsafe fn deallocate_pointer<P>(p: *mut P) {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -203,6 +203,21 @@ extern "C" {
     pub fn Export_RedisModule_InitAPI(ctx: *mut RedisModuleCtx) -> c_void;
 }
 
+// This is the one static function we need to initialize a module.
+// bindgen does not generate it for us (probably since it's defined as static in valkeymodule.h).
+#[allow(improper_ctypes)]
+#[link(name = "valkeymodule", kind = "static")]
+extern "C" {
+    pub fn Export_ValkeyModule_Init(
+        ctx: *mut ValkeyModuleCtx,
+        module_name: *const c_char,
+        module_version: c_int,
+        api_version: c_int,
+    ) -> c_int;
+
+    pub fn Export_ValkeyModule_InitAPI(ctx: *mut ValkeyModuleCtx) -> c_void;
+}
+
 ///////////////////////////////////////////////////////////////
 
 pub const FMT: *const c_char = b"v\0".as_ptr().cast::<c_char>();

--- a/src/valkeymodule.c
+++ b/src/valkeymodule.c
@@ -1,0 +1,13 @@
+#include "valkeymodule.h"
+
+// ValkeyModule_Init is defined as a static function and so won't be exported as
+// a symbol. Export a version under a slightly different name so that we can
+// get access to it from Rust.
+
+int Export_ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, int apiver) {
+    return ValkeyModule_Init(ctx, name, ver, apiver);
+}
+
+void Export_ValkeyModule_InitAPI(ValkeyModuleCtx *ctx) {
+    ValkeyModule_InitAPI(ctx);
+}


### PR DESCRIPTION
Use VM_Init by default and RM_Init only via a new feature flag

This PR addresses part 1 of this GitHub issue: https://github.com/valkey-io/valkeymodule-rs/issues/175