### PR TITLE
renamed function get_redis_version_* to get_server_version_*

### DIFF
--- a/examples/test_helper.rs
+++ b/examples/test_helper.rs
@@ -3,14 +3,14 @@ use valkey_module::InfoContext;
 use valkey_module::{valkey_module, Context, ValkeyError, ValkeyResult, ValkeyString};
 
 fn test_helper_version(ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
-    let ver = ctx.get_redis_version()?;
+    let ver = ctx.get_server_version()?;
     let response: Vec<i64> = vec![ver.major.into(), ver.minor.into(), ver.patch.into()];
 
     Ok(response.into())
 }
 
 fn test_helper_version_rm_call(ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
-    let ver = ctx.get_redis_version_rm_call()?;
+    let ver = ctx.get_server_version_rm_call()?;
     let response: Vec<i64> = vec![ver.major.into(), ver.minor.into(), ver.patch.into()];
 
     Ok(response.into())

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -719,13 +719,13 @@ impl Context {
 
     /// Returns the valkey version either by calling `RedisModule_GetServerVersion` API,
     /// Or if it is not available, by calling "info server" API and parsing the reply
-    pub fn get_redis_version(&self) -> Result<Version, ValkeyError> {
-        self.get_redis_version_internal(false)
+    pub fn get_server_version(&self) -> Result<Version, ValkeyError> {
+        self.get_server_version_internal(false)
     }
 
     /// Returns the valkey version by calling "info server" API and parsing the reply
-    pub fn get_redis_version_rm_call(&self) -> Result<Version, ValkeyError> {
-        self.get_redis_version_internal(true)
+    pub fn get_server_version_rm_call(&self) -> Result<Version, ValkeyError> {
+        self.get_server_version_internal(true)
     }
 
     pub fn version_from_info(info: ValkeyValue) -> Result<Version, ValkeyError> {
@@ -745,7 +745,7 @@ impl Context {
     }
 
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    fn get_redis_version_internal(&self, force_use_rm_call: bool) -> Result<Version, ValkeyError> {
+    fn get_server_version_internal(&self, force_use_rm_call: bool) -> Result<Version, ValkeyError> {
         match unsafe { raw::RedisModule_GetServerVersion } {
             Some(api) if !force_use_rm_call => {
                 // Call existing API


### PR DESCRIPTION
#### Description
Update this `get_redis_version_` alike function name to `get_server_version_`.

#### Testing

* `./build.sh` completed without error.
* `cargo test` passed locally