### PR TITLE
Make use-redismodule-api not required to be included in Cargo.toml of consumer modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,16 +108,13 @@ pub fn basic_info_command_handler(ctx: &InfoContext, for_crash_report: bool) {
         .for_each(|e| log::error!("Couldn't build info for the module's custom handler: {e}"));
 }
 
-/// Initialize RedisModuleAPI without register as a module.
-#[cfg(feature = "use-redismodule-api")]
+/// Initialize RedisModuleAPI or ValkeyModuleAPI without register as a module.
 pub fn init_api(ctx: &Context) {
-    unsafe { crate::raw::Export_RedisModule_InitAPI(ctx.ctx) };
-}
-
-/// Initialize ValkeyModuleAPI without register as a module.
-#[cfg(not(feature = "use-redismodule-api"))]
-pub fn init_api(ctx: &Context) {
-    unsafe { crate::raw::Export_ValkeyModule_InitAPI(ctx.ctx as *mut raw::ValkeyModuleCtx) };
+    if use_redis_module_api() {
+        unsafe { Export_RedisModule_InitAPI(ctx.ctx) };
+    } else {
+        unsafe { Export_ValkeyModule_InitAPI(ctx.ctx as *mut raw::ValkeyModuleCtx) };
+    }
 }
 
 pub(crate) unsafe fn deallocate_pointer<P>(p: *mut P) {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -239,8 +239,7 @@ macro_rules! valkey_module {
             // This block of code means that when Modules are compiled without the "use-redismodule-api" feature flag,
             // we expect that ValkeyModule_Init should succeed. We do not YET utilize the ValkeyModule_Init invocation
             // because the valkeymodule-rs still references RedisModule_* APIs for calls to the server.
-            #[cfg(not(feature = "use-redismodule-api"))]
-            {
+            if !raw::use_redis_module_api() {
                 let status = unsafe {
                     raw::Export_ValkeyModule_Init(
                         ctx as *mut raw::ValkeyModuleCtx,

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -218,6 +218,16 @@ extern "C" {
     pub fn Export_ValkeyModule_InitAPI(ctx: *mut ValkeyModuleCtx) -> c_void;
 }
 
+// Helper function to safely check whether the use-redismodule-api feature flag is enabled
+// without requiring consumers to include it in their Cargo.toml.
+pub fn use_redis_module_api() -> bool {
+    if cfg!(feature = "use-redismodule-api") {
+        true
+    } else {
+        false
+    }
+}
+
 ///////////////////////////////////////////////////////////////
 
 pub const FMT: *const c_char = b"v\0".as_ptr().cast::<c_char>();


### PR DESCRIPTION
This PR handles a cargo warning (not error) that modules will face when using `valkeymodule` crate version "0.1.5" if they do not include specify in their `Cargo.toml` whether they want the `use-redismodule-api` flag enabled or disabled. 
```
error: unexpected `cfg` condition value: `use-redismodule-api`
   --> src/lib.rs:96:1
    |
96  | / valkey_module! {
97  | |     name: MODULE_NAME,
98  | |     version: 1,
99  | |     allocator: (valkey_module::alloc::ValkeyAlloc, valkey_module::alloc::ValkeyAlloc),
...   |
137 | | }
    | |_^
```

With this PR, we make the `use-redismodule-api` feature flag not required to be included in the `Cargo.toml` of consumer modules. This removes the warning above even if the consumer module does not include the flag.



Without this PR, to disable the `use-redismodule-api ` feature (and not face the cargo warning), modules need to do the following in their Cargo.toml:

```
[features]
default = []
use-redismodule-api = [] # Leaving this empty means that we do not pass in the feature flag into the valkeymodule-rs SDK and this flag is left disabled
```

In summary, without this PR, consumer modules will need to make a `Cargo.toml` change OR ignore the cargo warning when using the `valkey-module` crate version: `0.1.5`.  With this PR, they do not need to make any changes to their `Cargo.toml` file (as it will default to the behavior of `use-redismodule-api` being disabled unless they specify this feature flag).

