### PR TITLE
Add custom auth callback support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,11 @@ crate-type = ["cdylib"]
 required-features = ["min-valkey-compatibility-version-8-0"]
 
 [[example]]
+name = "auth"
+crate-type = ["cdylib"]
+required-features = ["min-redis-compatibility-version-7-2"]
+
+[[example]]
 name = "call"
 crate-type = ["cdylib"]
 required-features = ["min-redis-compatibility-version-7-2"]

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -1,0 +1,493 @@
+//! Example authentication module demonstrating both non-blocking and blocking authentication flows.
+//!
+//! This module shows two authentication patterns:
+//! 1. Non-blocking authentication (auth_callback_one, auth_callback_two)
+//!    - Direct validation against credentials
+//!    - Immediate response
+//!
+//! 2. Blocking authentication (blocking_auth_callback_one, blocking_auth_callback_two)
+//!    - Asynchronous validation in separate threads
+//!    - Uses block_client_on_auth API
+
+use std::fmt;
+use std::os::raw::c_int;
+use std::thread::sleep;
+use valkey_module::alloc::ValkeyAlloc;
+use valkey_module::{
+    valkey_module, Context, Status, ValkeyError, ValkeyString, AUTH_HANDLED, AUTH_NOT_HANDLED,
+};
+
+// Represents the result of an authentication attempt
+#[derive(Debug, Copy, Clone)]
+enum AuthResult {
+    Allow, // Allow the authentication request - credentials are valid for this authentication module
+    Deny, // Deny the authentication request - credentials are invalid for this authentication module
+    Next, // Pass the authentication request to the next module in chain - this module cannot determine validity
+}
+
+// Private data structure used to pass authentication results between callbacks
+#[derive(Debug)]
+struct AuthPrivData {
+    result: AuthResult,
+}
+
+// Implement Display for AuthResult
+impl fmt::Display for AuthResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+// Common authentication function that validates user credentials against expected values
+//
+// # Arguments
+// * `ctx` - Valkey module context
+// * `username` - Username to validate
+// * `password` - Password to validate
+// * `expected_user` - Expected username
+// * `expected_pass` - Expected password
+// * `callback_name` - Name of the callback (for logging)
+fn authenticate_user_common(
+    ctx: &Context,
+    username: &ValkeyString,
+    password: &ValkeyString,
+    expected_user: &str,
+    expected_pass: &str,
+    callback_name: &str,
+) -> Result<c_int, ValkeyError> {
+    ctx.log_notice(&format!(
+        "{} auth attempt for user: {}",
+        callback_name, username
+    ));
+
+    // If username matches our expected user
+    if username.to_string() == expected_user {
+        // If password also matches - try to authenticate
+        if password.to_string() == expected_pass {
+            ctx.log_notice(&format!(
+                "{}: Matched user: {} with credentials",
+                callback_name, username
+            ));
+            match ctx.authenticate_client_with_acl_user(username) {
+                Status::Ok => {
+                    ctx.log_notice(&format!(
+                        "{}: Successfully authenticated user: {}",
+                        callback_name, username
+                    ));
+                    Ok(AUTH_HANDLED)
+                }
+                Status::Err => {
+                    ctx.log_warning(&format!(
+                        "{}: Failed to authenticate user: {} with ACL",
+                        callback_name, username
+                    ));
+                    Err(ValkeyError::Str("Failed to authenticate with ACL"))
+                }
+            }
+        } else {
+            // Username matches but password is wrong - explicit deny
+            ctx.log_notice(&format!(
+                "{}: Auth explicitly denied for user: {}",
+                callback_name, username
+            ));
+            if callback_name.contains("auth_one") {
+                Err(ValkeyError::Str(
+                    "DENIED: Authentication credentials mismatch in auth_one",
+                ))
+            } else if callback_name.contains("auth_two") {
+                Err(ValkeyError::Str(
+                    "DENIED: Authentication credentials mismatch in auth_two",
+                ))
+            } else {
+                Err(ValkeyError::Str(
+                    "DENIED: Authentication credentials mismatch for the user",
+                ))
+            }
+        }
+    } else {
+        // Username doesn't match - pass to next handler
+        ctx.log_notice(&format!(
+            "{}: auth not handled for user: {}",
+            callback_name, username
+        ));
+        Ok(AUTH_NOT_HANDLED)
+    }
+}
+
+// Authentication callback registered with Valkey via VM_RegisterAuthCallback
+//
+// This callback is registered in the authentication chain and processes authentication
+// requests for user1. It is registered as the first callback in the LIFO chain in this example.
+//
+// # Authentication Rules
+// Validates against:
+// - Username: "user1"
+// - Password: "module_pass1"
+//
+// # Arguments
+// * `ctx` - Valkey module context
+// * `username` - Username from client authentication attempt
+// * `password` - Password from client authentication attempt
+//
+// # Returns
+// * `Ok(AUTH_HANDLED)` - If authentication succeeds/fails for user1
+// * `Ok(AUTH_NOT_HANDLED)` - If credentials don't match user1 pattern
+// * `Err(ValkeyError)` - Provides the error response of authentication
+fn auth_callback_one(
+    ctx: &Context,
+    username: ValkeyString,
+    password: ValkeyString,
+) -> Result<c_int, ValkeyError> {
+    authenticate_user_common(
+        ctx,
+        &username,
+        &password,
+        "user1",
+        "module_pass1",
+        "auth_one",
+    )
+}
+
+// Authentication callback for user2
+//
+// Similar to `auth_callback_one` but handles user2/module_pass2 credentials.
+// Registered as the second callback in the LIFO chain.
+// See `auth_callback_one` for detailed documentation.
+//
+// # Authentication Rules
+// Validates against:
+// - Username: "user2"
+// - Password: "module_pass2"
+fn auth_callback_two(
+    ctx: &Context,
+    username: ValkeyString,
+    password: ValkeyString,
+) -> Result<c_int, ValkeyError> {
+    authenticate_user_common(
+        ctx,
+        &username,
+        &password,
+        "user2",
+        "module_pass2",
+        "auth_two",
+    )
+}
+
+// Common function for authentication reply callback that processes authentication results after client was unblocked
+//
+// # Arguments
+// * `ctx` - Valkey module context
+// * `username` - Username being authenticated
+// * `_password` - Password (unused in reply)
+// * `priv_data` - Optional private data for authentication
+// * `callback_name` - Name of the callback (for logging)
+fn auth_reply_callback_common(
+    ctx: &Context,
+    username: ValkeyString,
+    _password: ValkeyString,
+    priv_data: Option<&AuthPrivData>,
+    callback_name: &str,
+) -> Result<c_int, ValkeyError> {
+    match priv_data
+        .map(|data| data.result)
+        .unwrap_or(AuthResult::Next)
+    {
+        AuthResult::Allow => {
+            ctx.log_notice(&format!(
+                "{}: Auth allowed for user: {}",
+                callback_name, username
+            ));
+            match ctx.authenticate_client_with_acl_user(&username) {
+                Status::Ok => {
+                    ctx.log_notice(&format!(
+                        "{}: Successfully authenticated user: {}",
+                        callback_name, username
+                    ));
+                    Ok(AUTH_HANDLED)
+                }
+                Status::Err => {
+                    ctx.log_warning(&format!(
+                        "{}: Failed to authenticate user: {} with ACL",
+                        callback_name, username
+                    ));
+                    Err(ValkeyError::Str("Failed to authenticate with ACL"))
+                }
+            }
+        }
+        AuthResult::Deny => {
+            ctx.log_notice(&format!(
+                "{}: Auth explicitly denied for user: {}",
+                callback_name, username
+            ));
+            if callback_name.contains("blocked_auth_reply_one") {
+                Err(ValkeyError::Str(
+                    "DENIED: Authentication credentials mismatch in blocked_auth_reply_one",
+                ))
+            } else if callback_name.contains("blocked_auth_reply_two") {
+                Err(ValkeyError::Str(
+                    "DENIED: Authentication credentials mismatch in blocked_auth_reply_two",
+                ))
+            } else {
+                Err(ValkeyError::Str(
+                    "DENIED: Authentication credentials mismatch for the user",
+                ))
+            }
+        }
+        AuthResult::Next => {
+            ctx.log_notice(&format!(
+                "{}: Passing auth to next handler for user: {}",
+                callback_name, username
+            ));
+            Ok(AUTH_NOT_HANDLED)
+        }
+    }
+}
+
+// Reply callback for blocked clients used in blocking_auth_callback_one
+//
+// This callback is registered through ValkeyModule_BlockClientOnAuth API in blocking_auth_callback_one.
+// When the blocked client is unblocked using ValkeyModule_UnblockClient, the Valkey core will
+// automatically invoke this registered reply callback to process the authentication result.
+//
+// # Arguments
+//
+// * `ctx` - Valkey module context for executing commands and accessing Valkey functionality
+// * `username` - Username provided during authentication attempt
+// * `password` - Password provided during authentication attempt
+// * `priv_data` - Private data associated with the authentication context (Optional)
+//
+// # Returns
+// * `Result<c_int, ValkeyError>` - Returns OK (0) on success, or error code on failure
+fn auth_reply_callback_one(
+    ctx: &Context,
+    username: ValkeyString,
+    password: ValkeyString,
+    priv_data: Option<&AuthPrivData>,
+) -> Result<c_int, ValkeyError> {
+    auth_reply_callback_common(ctx, username, password, priv_data, "blocked_auth_reply_one")
+}
+
+// Reply callback for blocked clients used in blocking_auth_callback_two
+//
+// Similar to `auth_reply_callback_one` but handles replies for blocking_auth_callback_two.
+// See `auth_reply_callback_one` for detailed documentation.
+//
+// # Returns
+// * `Result<c_int, ValkeyError>` - Returns OK (0) on success, or error code on failure
+fn auth_reply_callback_two(
+    ctx: &Context,
+    username: ValkeyString,
+    password: ValkeyString,
+    priv_data: Option<&AuthPrivData>,
+) -> Result<c_int, ValkeyError> {
+    auth_reply_callback_common(ctx, username, password, priv_data, "blocked_auth_reply_two")
+}
+
+// Cleanup callback for private data in blocking_auth_callback_one
+//
+// This callback is registered through ValkeyModule_BlockClientOnAuth API along with the reply callback.
+// It is automatically invoked by Valkey core after the reply callback completes, following this sequence:
+// unblock client -> reply callback -> free privdata callback.
+//
+// # Important Note
+// This is an optional callback. If private data is allocated using ValkeyModule_Alloc or
+// ValkeyModule_Realloc, users must ensure they register this callback to properly free the
+// allocated memory to prevent memory leaks.
+//
+// # Arguments
+//
+// * `ctx` - Valkey module context for executing commands and logging
+// * `data` - Private authentication data to be cleaned up
+fn free_privdata_callback_one(ctx: &Context, data: AuthPrivData) {
+    // Handle cleanup with typed data
+    ctx.log_notice(&format!(
+        "free_privdata_callback_one: Cleaning up: {}",
+        data.result
+    ));
+    drop(data);
+}
+
+// Cleanup callback for private data in blocking_auth_callback_two
+//
+// Handles cleanup of authentication data for blockUser4-6.
+// Similar to `free_privdata_callback_one` but handles cleanup for different users.
+//
+// # Arguments
+// * `ctx` - Valkey module context for executing commands and logging
+// * `data` - Private authentication data to be cleaned up
+fn free_privdata_callback_two(ctx: &Context, data: AuthPrivData) {
+    // Handle cleanup with typed data
+    ctx.log_notice(&format!(
+        "free_privdata_callback_two: Cleaning up: {}",
+        data.result
+    ));
+    drop(data);
+}
+
+// Common implementation for blocking authentication handlers
+//
+// # Arguments
+// * `ctx` - Valkey module context
+// * `username` - Username to authenticate
+// * `password` - Password to validate
+// * `auth_reply_fn` - Function to handle authentication reply
+// * `free_callback_fn` - Optional cleanup callback
+// * `auth_patterns` - Function that defines authentication patterns and rules
+// * `callback_name` - Name of the callback (for logging)
+fn blocking_auth_common(
+    ctx: &Context,
+    username: ValkeyString,
+    password: ValkeyString,
+    auth_reply_fn: fn(
+        &Context,
+        ValkeyString,
+        ValkeyString,
+        Option<&AuthPrivData>,
+    ) -> Result<c_int, ValkeyError>,
+    free_callback_fn: Option<fn(&Context, AuthPrivData)>,
+    auth_patterns: impl Fn(&str, &str) -> AuthResult + Send + 'static,
+    callback_name: &str,
+) -> Result<c_int, ValkeyError> {
+    ctx.log_notice(&format!("{}: handling blocked client", callback_name));
+
+    if username.to_string() == "default" {
+        ctx.log_notice(&format!(
+            "{}: Default user authentication - passing to next handler",
+            callback_name
+        ));
+        return Ok(AUTH_NOT_HANDLED);
+    }
+
+    let username_str = username.to_string();
+    let password_str = password.to_string();
+    let callback_name_str = callback_name.to_string();
+
+    let mut blocked_client = ctx.block_client_on_auth(auth_reply_fn, free_callback_fn);
+
+    if callback_name_str == "blocking_auth_callback_two" {
+        if username_str == "blockAbort" && password_str == "abort" {
+            blocked_client.abort().unwrap_or_else(|e| {
+                ctx.log_notice(&format!("Failed to abort blocked client: {:?}", e));
+            });
+            ctx.reply_error_string("ERR ABORT: Authentication aborted by server");
+            return Ok(AUTH_HANDLED);
+        }
+    }
+
+    // Normal authentication flow in thread
+    std::thread::spawn(move || {
+        // This check specifically looks for the blockUserDelay user in the second callback
+        if callback_name_str == "blocking_auth_callback_two" && username_str == "blockUserDelay" {
+            sleep(std::time::Duration::from_secs(2));
+        }
+
+        let result = auth_patterns(&username_str, &password_str);
+        blocked_client.set_blocked_private_data(AuthPrivData { result });
+    });
+
+    Ok(AUTH_HANDLED)
+}
+
+// Authentication callback registered with Valkey via VM_RegisterAuthCallback
+//
+// This blocking handler processes authentication requests asynchronously for blockUser1-3.
+// It is registered as the third callback in the LIFO chain in this example.
+//
+// # Authentication Rules
+// - Allowed combinations:
+//   * username: "blockUser1", password: "module_blockPass1"
+//   * username: "blockUser2", password: "module_blockPass2"
+//   * username: "blockUser3", password: "module_blockPass3"
+// - Any other password for blockUser1/blockUser2/blockUser3: Denied
+// - All other usernames: Passed to next handler in chain
+//
+// # Arguments
+// * `ctx` - Valkey module context
+// * `username` - Username from client authentication attempt
+// * `password` - Password from client authentication attempt
+//
+// # Returns
+// * `Ok(AUTH_HANDLED)` - Authentication was processed asynchronously
+// * `Err(ValkeyError)` - Provides the error response of authentication
+fn blocking_auth_callback_one(
+    ctx: &Context,
+    username: ValkeyString,
+    password: ValkeyString,
+) -> Result<c_int, ValkeyError> {
+    blocking_auth_common(
+        ctx,
+        username,
+        password,
+        auth_reply_callback_one,
+        Some(free_privdata_callback_one),
+        |user, pass| match (user, pass) {
+            ("blockUser1", "module_blockPass1") => AuthResult::Allow,
+            ("blockUser2", "module_blockPass2") => AuthResult::Allow,
+            ("blockUser3", "module_blockPass3") => AuthResult::Allow,
+            ("blockUser1", _) | ("blockUser2", _) | ("blockUser3", _) => AuthResult::Deny,
+            _ => AuthResult::Next,
+        },
+        "blocking_auth_callback_one",
+    )
+}
+
+// Authentication callback for blockUser4-6
+//
+// Similar to blocking_auth_callback_one but handles a different set of users.
+// Registered as the fourth (last) callback in the LIFO chain.
+//
+// # Authentication Rules
+// - Allowed combinations:
+//   * username: "blockUser4", password: "module_blockPass4"
+//   * username: "blockUser5", password: "module_blockPass5"
+//   * username: "blockUser6", password: "blockPass6"
+//     (Special test user that simulates a 2-second authentication delay)
+//   * username: "blockUserDelay", password: "blockPassDelay"
+// - Any other password for these users: Denied
+// - All other usernames: Passed to next handler
+fn blocking_auth_callback_two(
+    ctx: &Context,
+    username: ValkeyString,
+    password: ValkeyString,
+) -> Result<c_int, ValkeyError> {
+    blocking_auth_common(
+        ctx,
+        username,
+        password,
+        auth_reply_callback_two,
+        Some(free_privdata_callback_two),
+        |user, pass| match (user, pass) {
+            ("blockUser4", "module_blockPass4") => AuthResult::Allow,
+            ("blockUser5", "module_blockPass5") => AuthResult::Allow,
+            ("blockUser6", "module_blockPass6") => AuthResult::Allow,
+            ("blockUserDelay", "blockPassDelay") => AuthResult::Allow,
+            ("blockUser4", _) | ("blockUser5", _) | ("blockUser6", _) | ("blockUserDelay", _) => {
+                AuthResult::Deny
+            }
+            _ => AuthResult::Next,
+        },
+        "blocking_auth_callback_two",
+    )
+}
+
+//////////////////////////////////////////////////////
+
+// Valkey module declaration for authentication
+// Registers authentication callbacks in LIFO (Last In, First Out) order:
+// 4. blocking_auth_callback_two
+// 3. blocking_auth_callback_one
+// 2. auth_callback_two
+// 1. auth_callback_one
+valkey_module! {
+    name: "auth",
+    version: 1,
+    allocator: (ValkeyAlloc, ValkeyAlloc),
+    data_types: [],
+    auth: [
+        blocking_auth_callback_two,
+        blocking_auth_callback_one,
+        auth_callback_two,
+        auth_callback_one
+    ],
+    commands: []
+}

--- a/src/context/auth.rs
+++ b/src/context/auth.rs
@@ -1,0 +1,32 @@
+use crate::{raw, Context, ValkeyString};
+use std::os::raw::{c_char, c_int};
+use std::ptr;
+
+impl Context {
+    /// Authenticates a client using an ACL user
+    ///
+    /// # Arguments
+    /// * `username` - ACL username to authenticate with
+    ///
+    /// # Returns
+    /// * `Status::Ok` - Authentication successful
+    /// * `Status::Err` - Authentication failed
+    pub fn authenticate_client_with_acl_user(&self, username: &ValkeyString) -> raw::Status {
+        let result = unsafe {
+            raw::RedisModule_AuthenticateClientWithACLUser.unwrap()(
+                self.ctx,
+                username.as_ptr().cast::<c_char>(),
+                username.len(),
+                None,
+                ptr::null_mut(),
+                ptr::null_mut(),
+            )
+        };
+
+        if result == raw::REDISMODULE_OK as c_int {
+            raw::Status::Ok
+        } else {
+            raw::Status::Err
+        }
+    }
+}

--- a/src/context/blocked.rs
+++ b/src/context/blocked.rs
@@ -121,18 +121,20 @@ impl<T> BlockedClient<T> {
 
     /// Sets private data for the blocked client.
     ///
-    /// # Panics
-    /// This method will panic if called without first setting a free callback.
-    /// The free callback is required to properly clean up any resources associated
-    /// with the private data.
-    ///
     /// # Arguments
     /// * `data` - The private data to store
-    pub fn set_blocked_private_data(&mut self, data: T) {
+    ///
+    /// # Returns
+    /// * `Ok(())` - If the private data was successfully set
+    /// * `Err(ValkeyError)` - If setting the private data failed (e.g., no free callback)
+    pub fn set_blocked_private_data(&mut self, data: T) -> Result<(), ValkeyError> {
         if self.free_callback.is_none() {
-            panic!("Cannot set private data without a free callback - this would leak memory");
+            return Err(ValkeyError::Str(
+                "Cannot set private data without a free callback - this would leak memory",
+            ));
         }
         self.data = Some(Box::new(data));
+        Ok(())
     }
 
     /// Aborts the blocked client operation

--- a/src/context/blocked.rs
+++ b/src/context/blocked.rs
@@ -1,18 +1,181 @@
-use std::ptr;
+use crate::redismodule::AUTH_HANDLED;
+use crate::{raw, Context, ValkeyError, ValkeyString};
+use std::os::raw::{c_int, c_void};
 
-use crate::raw;
-use crate::Context;
+// Callback types for handling blocked client operations
+// Currently supports authentication reply callback for block_client_on_auth
+#[derive(Debug)]
+pub enum ReplyCallback<T> {
+    Auth(fn(&Context, ValkeyString, ValkeyString, Option<&T>) -> Result<c_int, ValkeyError>),
+}
 
-pub struct BlockedClient {
+#[derive(Debug)]
+struct BlockedClientPrivateData<T: 'static> {
+    reply_callback: Option<ReplyCallback<T>>,
+    free_callback: Option<FreePrivateDataCallback<T>>,
+    data: Option<Box<T>>,
+}
+
+// Callback type for freeing private data associated with a blocked client
+type FreePrivateDataCallback<T> = fn(&Context, T);
+
+pub struct BlockedClient<T: 'static = ()> {
     pub(crate) inner: *mut raw::RedisModuleBlockedClient,
+    reply_callback: Option<ReplyCallback<T>>,
+    free_callback: Option<FreePrivateDataCallback<T>>,
+    data: Option<Box<T>>,
+}
+
+#[allow(dead_code)]
+unsafe extern "C" fn auth_reply_wrapper<T: 'static>(
+    ctx: *mut raw::RedisModuleCtx,
+    username: *mut raw::RedisModuleString,
+    password: *mut raw::RedisModuleString,
+    err: *mut *mut raw::RedisModuleString,
+) -> c_int {
+    let context = Context::new(ctx);
+    let ctx_ptr = std::ptr::NonNull::new_unchecked(ctx);
+    let username = ValkeyString::new(Some(ctx_ptr), username);
+    let password = ValkeyString::new(Some(ctx_ptr), password);
+
+    let module_private_data = context.get_blocked_client_private_data();
+    if module_private_data.is_null() {
+        panic!("[auth_reply_wrapper] Module private data is null; this should not happen!");
+    }
+
+    let user_private_data = &*(module_private_data as *const BlockedClientPrivateData<T>);
+
+    let cb = match user_private_data.reply_callback.as_ref() {
+        Some(ReplyCallback::Auth(cb)) => cb,
+        None => panic!("[auth_reply_wrapper] Reply callback is null; this should not happen!"),
+    };
+
+    let data_ref = user_private_data.data.as_deref();
+
+    match cb(&context, username, password, data_ref) {
+        Ok(result) => result,
+        Err(error) => {
+            let error_msg = ValkeyString::create_and_retain(&error.to_string());
+            *err = error_msg.inner;
+            AUTH_HANDLED
+        }
+    }
+}
+
+#[allow(dead_code)]
+unsafe extern "C" fn free_callback_wrapper<T: 'static>(
+    ctx: *mut raw::RedisModuleCtx,
+    module_private_data: *mut c_void,
+) {
+    let context = Context::new(ctx);
+
+    if module_private_data.is_null() {
+        panic!("[free_callback_wrapper] Module private data is null; this should not happen!");
+    }
+
+    let user_private_data = Box::from_raw(module_private_data as *mut BlockedClientPrivateData<T>);
+
+    // Execute free_callback only if both callback and data exist
+    // Note: free_callback can exist without data - this is a valid state
+    if let Some(free_cb) = user_private_data.free_callback {
+        if let Some(data) = user_private_data.data {
+            free_cb(&context, *data);
+        }
+    }
 }
 
 // We need to be able to send the inner pointer to another thread
-unsafe impl Send for BlockedClient {}
+unsafe impl<T> Send for BlockedClient<T> {}
 
-impl Drop for BlockedClient {
+impl<T> BlockedClient<T> {
+    pub(crate) fn new(inner: *mut raw::RedisModuleBlockedClient) -> Self {
+        Self {
+            inner,
+            reply_callback: None,
+            free_callback: None,
+            data: None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn with_auth_callback(
+        inner: *mut raw::RedisModuleBlockedClient,
+        auth_reply_callback: fn(
+            &Context,
+            ValkeyString,
+            ValkeyString,
+            Option<&T>,
+        ) -> Result<c_int, ValkeyError>,
+        free_callback: Option<FreePrivateDataCallback<T>>,
+    ) -> Self
+    where
+        T: 'static,
+    {
+        Self {
+            inner,
+            reply_callback: Some(ReplyCallback::Auth(auth_reply_callback)),
+            free_callback,
+            data: None,
+        }
+    }
+
+    /// Sets private data for the blocked client.
+    ///
+    /// # Panics
+    /// This method will panic if called without first setting a free callback.
+    /// The free callback is required to properly clean up any resources associated
+    /// with the private data.
+    ///
+    /// # Arguments
+    /// * `data` - The private data to store
+    pub fn set_blocked_private_data(&mut self, data: T) {
+        if self.free_callback.is_none() {
+            panic!("Cannot set private data without a free callback - this would leak memory");
+        }
+        self.data = Some(Box::new(data));
+    }
+
+    /// Aborts the blocked client operation
+    ///
+    /// # Returns
+    /// * `Ok(())` - If the blocked client was successfully aborted
+    /// * `Err(ValkeyError)` - If the abort operation failed
+    pub fn abort(mut self) -> Result<(), ValkeyError> {
+        unsafe {
+            // Clear references to data and callbacks
+            self.data = None;
+            self.reply_callback = None;
+            self.free_callback = None;
+
+            if raw::RedisModule_AbortBlock.unwrap()(self.inner) == raw::REDISMODULE_OK as c_int {
+                // Prevent the normal Drop from running
+                self.inner = std::ptr::null_mut();
+                Ok(())
+            } else {
+                Err(ValkeyError::Str("Failed to abort blocked client"))
+            }
+        }
+    }
+}
+
+impl<T: 'static> Drop for BlockedClient<T> {
     fn drop(&mut self) {
-        unsafe { raw::RedisModule_UnblockClient.unwrap()(self.inner, ptr::null_mut()) };
+        if !self.inner.is_null() {
+            let callback_data_ptr = if self.reply_callback.is_some() || self.free_callback.is_some()
+            {
+                Box::into_raw(Box::new(BlockedClientPrivateData {
+                    reply_callback: self.reply_callback.take(),
+                    free_callback: self.free_callback.take(),
+                    data: self.data.take(),
+                })) as *mut c_void
+            } else {
+                std::ptr::null_mut()
+            };
+
+            unsafe {
+                raw::RedisModule_UnblockClient.unwrap()(self.inner, callback_data_ptr);
+            }
+        }
     }
 }
 
@@ -28,8 +191,56 @@ impl Context {
             )
         };
 
-        BlockedClient {
-            inner: blocked_client,
+        BlockedClient::new(blocked_client)
+    }
+
+    /// Blocks a client during authentication and registers callbacks
+    ///
+    /// Wrapper around ValkeyModule_BlockClientOnAuth. Used for asynchronous authentication
+    /// processing.
+    ///
+    /// # Arguments
+    /// * `auth_reply_callback` - Callback executed when authentication completes
+    /// * `free_callback` - Optional callback for cleaning up private data
+    ///
+    /// # Returns
+    /// * `BlockedClient<T>` - Handle to manage the blocked client
+    #[must_use]
+    #[cfg(all(any(
+        feature = "min-redis-compatibility-version-7-2",
+        feature = "min-valkey-compatibility-version-8-0"
+    ),))]
+    pub fn block_client_on_auth<T: 'static + Send>(
+        &self,
+        auth_reply_callback: fn(
+            &Context,
+            ValkeyString,
+            ValkeyString,
+            Option<&T>,
+        ) -> Result<c_int, ValkeyError>,
+        free_callback: Option<FreePrivateDataCallback<T>>,
+    ) -> BlockedClient<T> {
+        unsafe {
+            let blocked_client = raw::RedisModule_BlockClientOnAuth.unwrap()(
+                self.ctx,
+                Some(auth_reply_wrapper::<T>),
+                Some(free_callback_wrapper::<T>),
+            );
+
+            BlockedClient::with_auth_callback(blocked_client, auth_reply_callback, free_callback)
         }
+    }
+
+    /// Retrieves the private data associated with a blocked client in the current context.
+    /// This is an internal function used primarily by reply callbacks to access user-provided data.
+    ///
+    /// # Safety
+    /// This function returns a raw pointer that must be properly cast to the expected type.
+    /// The caller must ensure the pointer is not null before dereferencing.
+    ///
+    /// # Implementation Detail
+    /// Wraps the Valkey Module C API function `ValkeyModule_GetBlockedClientPrivateData`
+    pub(crate) fn get_blocked_client_private_data(&self) -> *mut c_void {
+        unsafe { raw::RedisModule_GetBlockedClientPrivateData.unwrap()(self.ctx) }
     }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -27,6 +27,7 @@ use self::thread_safe::ValkeyLockIndicator;
 
 mod timer;
 
+pub mod auth;
 pub mod blocked;
 pub mod call_reply;
 pub mod client;

--- a/src/context/thread_safe.rs
+++ b/src/context/thread_safe.rs
@@ -145,9 +145,9 @@ impl Default for ThreadSafeContext<DetachedFromClient> {
     }
 }
 
-impl ThreadSafeContext<BlockedClient> {
+impl<T: Send> ThreadSafeContext<BlockedClient<T>> {
     #[must_use]
-    pub fn with_blocked_client(blocked_client: BlockedClient) -> Self {
+    pub fn with_blocked_client(blocked_client: BlockedClient<T>) -> Self {
         let ctx = unsafe { raw::RedisModule_GetThreadSafeContext.unwrap()(blocked_client.inner) };
         Self {
             ctx,

--- a/src/redismodule.rs
+++ b/src/redismodule.rs
@@ -38,6 +38,8 @@ impl From<ValkeyError> for ValkeyValueResult {
 
 pub const VALKEY_OK: ValkeyValueResult = Ok(ValkeyValue::SimpleStringStatic("OK"));
 pub const TYPE_METHOD_VERSION: u64 = raw::REDISMODULE_TYPE_METHOD_VERSION as u64;
+pub const AUTH_HANDLED: i32 = raw::REDISMODULE_AUTH_HANDLED as i32;
+pub const AUTH_NOT_HANDLED: i32 = raw::REDISMODULE_AUTH_NOT_HANDLED as i32;
 
 pub trait NextArg {
     fn next_arg(&mut self) -> Result<ValkeyString, ValkeyError>;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7,7 +7,10 @@ use anyhow::Result;
 use redis::Commands;
 use redis::Value;
 use redis::{RedisError, RedisResult};
-use utils::{get_valkey_connection, start_valkey_server_with_module};
+use utils::{
+    check_auth, check_blocked_clients, get_valkey_connection, setup_acl_users,
+    start_valkey_server_with_module, AuthExpectedResult,
+};
 
 const FAILED_TO_START_SERVER: &str = "failed to start valkey server";
 const FAILED_TO_CONNECT_TO_SERVER: &str = "failed to connect to valkey server";
@@ -1222,6 +1225,391 @@ fn test_preload() -> Result<()> {
         .arg(&["UNLOAD", "preload"])
         .exec(&mut con)
         .with_context(|| "failed to unload module")?;
+
+    Ok(())
+}
+
+// Tests basic non-blocking authentication functionality.
+// Verifies that:
+// - Users can be created and authenticated successfully with correct credentials
+// - Authentication fails when incorrect passwords are provided
+#[test]
+fn test_non_blocking_auth_callbacks() -> Result<()> {
+    let port = 6513;
+    let _guards =
+        vec![start_valkey_server_with_module("auth", port)
+            .with_context(|| FAILED_TO_START_SERVER)?];
+
+    let mut con = get_valkey_connection(port).with_context(|| FAILED_TO_CONNECT_TO_SERVER)?;
+
+    // Module users - these are handled by the module
+    let module_users = [("user1", "module_pass1"), ("user2", "module_pass2")];
+
+    // Engine users - completely different users that should fall through to engine
+    let engine_users = [
+        ("engine_user1", "engine_pass1"),
+        ("engine_user2", "engine_pass2"),
+    ];
+
+    // Setup ACL users - both module users (no engine pass) and engine users (with pass)
+    setup_acl_users(
+        &mut con,
+        &module_users
+            .iter()
+            .map(|(u, _)| (*u, None))
+            .collect::<Vec<_>>(),
+    )?;
+    setup_acl_users(
+        &mut con,
+        &engine_users
+            .iter()
+            .map(|(u, p)| (*u, Some(*p)))
+            .collect::<Vec<_>>(),
+    )?;
+
+    // Test 1: Module authentication
+    for (user, module_pass) in module_users.iter() {
+        // Correct module password should succeed
+        check_auth(&mut con, user, module_pass, AuthExpectedResult::Success)?;
+        // Wrong password for module user should be denied by module
+        check_auth(&mut con, user, "wrong", AuthExpectedResult::Denied)?;
+    }
+
+    // Test 2: Engine authentication (different users falling through)
+    for (user, engine_pass) in engine_users.iter() {
+        // Engine users should succeed with correct password
+        check_auth(&mut con, user, engine_pass, AuthExpectedResult::Success)?;
+        // Engine users should fail with wrong password
+        check_auth(&mut con, user, "wrong", AuthExpectedResult::EngineDenied)?;
+    }
+
+    Ok(())
+}
+
+// Tests blocking authentication functionality.
+// Verifies that:
+// - Authentication requests can block for specified duration
+// - Blocked clients are correctly reported in server metrics
+// - Successful and failed authentications work as expected
+// - Authentication can be aborted
+#[test]
+fn test_blocking_auth_callbacks() -> Result<()> {
+    let port = 6514;
+    let _guards =
+        vec![start_valkey_server_with_module("auth", port)
+            .with_context(|| FAILED_TO_START_SERVER)?];
+
+    let mut con = get_valkey_connection(port).with_context(|| FAILED_TO_CONNECT_TO_SERVER)?;
+    let mut con2 = get_valkey_connection(port).with_context(|| FAILED_TO_CONNECT_TO_SERVER)?;
+    let mut con3 = get_valkey_connection(port).with_context(|| FAILED_TO_CONNECT_TO_SERVER)?;
+
+    // Set up users for blocking auth
+    let users = [
+        ("blockUser4", "module_blockPass4"),
+        ("blockUser5", "module_blockPass5"),
+        ("blockUser6", "module_blockPass6"),
+        ("blockUserDelay", "blockPassDelay"),
+    ];
+
+    // Set up engine users
+    let engine_users = [
+        ("engine_user1", "engine_pass1"),
+        ("engine_user2", "engine_pass2"),
+    ];
+
+    // Setup ACL users (no passwords needed)
+    setup_acl_users(
+        &mut con,
+        &users.iter().map(|(u, _)| (*u, None)).collect::<Vec<_>>(),
+    )?;
+    // Setup engine users (with passwords)
+    setup_acl_users(
+        &mut con,
+        &engine_users
+            .iter()
+            .map(|(u, p)| (*u, Some(*p)))
+            .collect::<Vec<_>>(),
+    )?;
+
+    // Start auth on first connection with blockUserDelay user as it would create
+    // 2-second delay for the testing purpose
+    let auth_handle = std::thread::spawn(move || {
+        let _: RedisResult<String> = redis::cmd("AUTH")
+            .arg(&["blockUserDelay", "blockPassDelay"])
+            .query(&mut con);
+    });
+
+    // Wait half a second (during the 2-second delay) to check blocked clients
+    // as the engine would take some time to reflect in its metrics
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    // Check blocked_clients from second connection
+    let blocked_clients = check_blocked_clients(&mut con2)?;
+    assert!(
+        blocked_clients > 0,
+        "Expected to see blocked clients during auth"
+    );
+
+    // Wait for auth to complete
+    auth_handle.join().unwrap();
+
+    // Test successful blocking authentications with third connection
+    for (user, module_pass) in users.iter() {
+        check_auth(&mut con3, user, module_pass, AuthExpectedResult::Success)?;
+    }
+
+    // Test failed blocking authentications
+    for (user, _) in users.iter() {
+        check_auth(&mut con3, user, "wrong", AuthExpectedResult::Denied)?;
+    }
+
+    // Test engine authentication (fallback)
+    for (user, pass) in engine_users.iter() {
+        check_auth(&mut con3, user, pass, AuthExpectedResult::Success)?;
+        check_auth(&mut con3, user, "wrong", AuthExpectedResult::EngineDenied)?;
+    }
+
+    // Test abort authentication case
+    check_auth(
+        &mut con3,
+        "blockAbort",
+        "abort",
+        AuthExpectedResult::Aborted,
+    )?;
+
+    Ok(())
+}
+
+// This test verifies that multiple concurrent authentication callbacks are properly isolated
+// and the correct callback is invoked for each client, even under concurrent load.
+//
+// Test scenario:
+// 1. Sets up two groups of users:
+//    - users_auth1: Uses blocking_auth_callback_one (fast authentication)
+//    - users_auth2: Uses blocking_auth_callback_two (2-second delayed authentication for some users)
+//
+// 2. Creates authentication requests in this order:
+//    a. Starts auth2 requests first
+//    b. While auth2 requests are blocked, immediately starts auth1 requests
+//
+// 3. Verifies callback isolation by leveraging reply callback name in deny
+// error response in this example and ensure:
+//    - All auth1 users get errors containing "blocked_auth_reply_one" reply callback
+//    - All auth2 users get errors containing "blocked_auth_reply_two" reply callback
+//
+// This test demonstrates that:
+// - Authentication callbacks remain isolated even under concurrent load
+// - The correct callback is invoked for each user group
+// - Callbacks are not mixed up even when faster authentications (auth1)
+//   complete while slower ones (auth2 with delay) are still processing
+#[test]
+fn test_multiple_inflight_blocking_auth_callbacks() -> Result<()> {
+    let port = 6515;
+    let _guards =
+        vec![start_valkey_server_with_module("auth", port)
+            .with_context(|| FAILED_TO_START_SERVER)?];
+
+    let mut setup_con = get_valkey_connection(port).with_context(|| FAILED_TO_CONNECT_TO_SERVER)?;
+
+    // Set up users for both auth callbacks with (username, module_pass)
+    let users_auth1 = [
+        ("blockUser1", "module_blockPass1"),
+        ("blockUser2", "module_blockPass2"),
+        ("blockUser3", "module_blockPass3"),
+    ];
+
+    let users_auth2 = [
+        ("blockUser4", "module_blockPass4"),
+        ("blockUser5", "module_blockPass5"),
+        ("blockUser6", "module_blockPass6"),
+        ("blockUserDelay", "blockPassDelay"),
+    ];
+
+    // Create all users in ACL with no passwords
+    setup_acl_users(
+        &mut setup_con,
+        &users_auth1
+            .iter()
+            .map(|(u, _)| (*u, None))
+            .collect::<Vec<_>>(),
+    )?;
+    setup_acl_users(
+        &mut setup_con,
+        &users_auth2
+            .iter()
+            .map(|(u, _)| (*u, None))
+            .collect::<Vec<_>>(),
+    )?;
+
+    // Start multiple auth2 connections with wrong passwords
+    let auth2_handles: Vec<_> = users_auth2
+        .iter()
+        .map(|(user, _)| {
+            let mut con = get_valkey_connection(port)
+                .with_context(|| FAILED_TO_CONNECT_TO_SERVER)
+                .unwrap();
+            let user = user.to_string();
+            let wrong_pass = "wrong".to_string();
+
+            std::thread::spawn(move || {
+                let res: RedisResult<String> = redis::cmd("AUTH")
+                    .arg(&[&user, &wrong_pass])
+                    .query(&mut con);
+                (user, res)
+            })
+        })
+        .collect();
+
+    // While auth2 requests are blocked, try auth1 requests with wrong passwords
+    let auth1_handles: Vec<_> = users_auth1
+        .iter()
+        .map(|(user, _)| {
+            let mut con = get_valkey_connection(port)
+                .with_context(|| FAILED_TO_CONNECT_TO_SERVER)
+                .unwrap();
+            let user = user.to_string();
+            let wrong_pass = "wrong".to_string();
+
+            std::thread::spawn(move || {
+                let res: RedisResult<String> = redis::cmd("AUTH")
+                    .arg(&[&user, &wrong_pass])
+                    .query(&mut con);
+                (user, res)
+            })
+        })
+        .collect();
+
+    let auth2_results: Vec<(String, RedisResult<String>)> = auth2_handles
+        .into_iter()
+        .map(|handle| handle.join().unwrap())
+        .collect();
+
+    let auth1_results: Vec<(String, RedisResult<String>)> = auth1_handles
+        .into_iter()
+        .map(|handle| handle.join().unwrap())
+        .collect();
+
+    // Verify auth2 results have the correct callback error message
+    for (user, result) in auth2_results {
+        match result {
+            Ok(_) => panic!("Authentication should have failed for user {}", user),
+            Err(e) => {
+                let err_str = e.to_string();
+                assert!(
+                    err_str.contains("blocked_auth_reply_two"),
+                    "Wrong callback for user {}: expected 'blocked_auth_reply_two' in error, got: {}",
+                    user,
+                    err_str
+                );
+            }
+        }
+    }
+
+    // Verify auth1 results have the correct callback error message
+    for (user, result) in auth1_results {
+        match result {
+            Ok(_) => panic!("Authentication should have failed for user {}", user),
+            Err(e) => {
+                let err_str = e.to_string();
+                assert!(
+                    err_str.contains("blocked_auth_reply_one"),
+                    "Wrong callback for user {}: expected 'blocked_auth_reply_one' in error, got: {}",
+                    user,
+                    err_str
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// This test verifies proper cleanup of blocked clients during authentication when a client disconnects.
+//
+//
+// The test ensures:
+// - Proper cleanup of blocked client resources when client disconnects mid-authentication
+// - No memory leaks occur (when run with Address Sanitizer)
+// - Server maintains correct blocked client count
+//
+// This simulates real-world scenarios where clients may disconnect during authentication,
+// such as network issues or client termination.
+#[test]
+fn test_disconnect_client_during_blocking_auth() -> Result<()> {
+    let port = 6516;
+    let _guards =
+        vec![start_valkey_server_with_module("auth", port)
+            .with_context(|| FAILED_TO_START_SERVER)?];
+
+    let mut con = get_valkey_connection(port).with_context(|| FAILED_TO_CONNECT_TO_SERVER)?;
+    let mut monitor_con =
+        get_valkey_connection(port).with_context(|| FAILED_TO_CONNECT_TO_SERVER)?;
+
+    // Set up test user with delay for testing blocking behavior
+    let users = [("blockUserDelay", "blockPassDelay")];
+    setup_acl_users(
+        &mut con,
+        &users.iter().map(|(u, _)| (*u, None)).collect::<Vec<_>>(),
+    )?;
+
+    // Start auth in a separate thread that will be disconnected
+    let users_clone = users; // Clone the array for the thread
+    let auth_handle = std::thread::spawn(move || {
+        let (user, module_pass) = users_clone[0]; // Using the first (and only) user
+        let result: RedisResult<String> =
+            redis::cmd("AUTH").arg(&[user, module_pass]).query(&mut con);
+
+        // We expect this to fail due to connection being closed
+        match result {
+            Ok(_) => panic!("Authentication should have failed due to disconnection"),
+            Err(e) => {
+                let err = e.to_string();
+                assert!(
+                    err.contains("end of file"),
+                    "Expected 'end of file' error, got: {}",
+                    err
+                );
+            }
+        }
+    });
+
+    // Wait to ensure auth is blocked and reflected in server metrics
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    // Verify client is blocked
+    let blocked_clients = check_blocked_clients(&mut monitor_con)?;
+    assert!(
+        blocked_clients > 0,
+        "Expected to see blocked clients during auth"
+    );
+
+    // Force disconnect all clients except our monitoring connection
+    redis::cmd("CLIENT")
+        .arg(&["KILL", "SKIPME", "YES"])
+        .query::<()>(&mut monitor_con)?;
+
+    // Verify blocked clients count is now 0
+    let blocked_clients_after = check_blocked_clients(&mut monitor_con)?;
+    assert_eq!(
+        blocked_clients_after, 0,
+        "Expected no blocked clients after disconnect"
+    );
+
+    // Wait for auth thread to complete and handle any panics
+    auth_handle.join().unwrap_or_else(|e| {
+        panic!("Auth thread panicked: {:?}", e);
+    });
+
+    // Verify we can still authenticate with a new connection
+    let mut verify_con =
+        get_valkey_connection(port).with_context(|| FAILED_TO_CONNECT_TO_SERVER)?;
+    let (user, module_pass) = users[0];
+    check_auth(
+        &mut verify_con,
+        user,
+        module_pass,
+        AuthExpectedResult::Success,
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds custom authentication callback support for Valkey modules:

Key Features:
- Support multiple custom authentication callbacks via `valkey_module_auth` macro
- Safe Rust wrappers for blocking and non-blocking authentication mechanisms.
- Implement ACL user authentication via safe wrapper of  `ValkeyModule_AuthenticateClientWithACLUser`
- Enable thread-safe authentication state management between auth handlers and reply callbacks by extending set and get private data APIs in blocked.rs
- Support abort client handling to handle some edge cases like resource allocation failures etc.

Implementation includes safe abstractions around Valkey Module C APIs, providing module developers with flexible/safe interfaces for custom authentication workflows while handling all unsafe conversions internally.