### PR TITLE
perform validation before module load

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,10 @@ crate-type = ["cdylib"]
 name = "filter2"
 crate-type = ["cdylib"]
 
+[[example]]
+name = "preload"
+crate-type = ["cdylib"]
+
 [dependencies]
 bitflags = "2.8.0"
 libc = "0.2"

--- a/examples/preload.rs
+++ b/examples/preload.rs
@@ -1,0 +1,23 @@
+use valkey_module::alloc::ValkeyAlloc;
+use valkey_module::{valkey_module, Context, Status, ValkeyString};
+
+fn preload(ctx: &Context, args: &[ValkeyString]) -> Status {
+    // perform preload validations here, useful for MODULE LOAD
+    // unlike init which is called at the end of the valkey_module! macro this is called at the beginning
+    let version = ctx.get_server_version().unwrap();
+    ctx.log_notice(&format!(
+        "preload for server version {:?} with args: {:?}",
+        version, args
+    ));
+    // respond with either Status::Ok or Status::Err (if you want to prevent module loading)
+    Status::Ok
+}
+
+valkey_module! {
+    name: "preload",
+    version: 1,
+    allocator: (ValkeyAlloc, ValkeyAlloc),
+    data_types: [],
+    preload: preload,
+    commands: [],
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -126,6 +126,7 @@ macro_rules! valkey_module {
         data_types: [
             $($data_type:ident),* $(,)*
         ],
+        $(preload: $preload_func:ident,)* $(,)*
         $(init: $init_func:ident,)* $(,)*
         $(deinit: $deinit_func:ident,)* $(,)*
         $(info: $info_func:ident,)?
@@ -295,6 +296,15 @@ macro_rules! valkey_module {
                 let _ = $crate::MODULE_CONTEXT.set_context(&context);
             }
             let args = $crate::decode_args(ctx, argv, argc);
+
+            // perform validation BEFORE loading the module
+            // exit if there are any issues BEFORE registering commands, data types, etc
+            // different from init_func which is done at the end and allows to take advantage of things that were done in the macro
+            $(
+                if $preload_func(&context, &args) == $crate::Status::Err {
+                    return $crate::Status::Err as c_int;
+                }
+            )*
 
             $(
                 if (&$data_type).create_data_type(ctx).is_err() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1151,3 +1151,19 @@ fn test_filter() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_preload() -> Result<()> {
+    let port = 6512;
+    let _guards =
+        vec![start_valkey_server_with_module("preload", port)
+            .with_context(|| FAILED_TO_START_SERVER)?];
+    let mut con = get_valkey_connection(port).with_context(|| FAILED_TO_CONNECT_TO_SERVER)?;
+    // unload the module
+    redis::cmd("MODULE")
+        .arg(&["UNLOAD", "preload"])
+        .exec(&mut con)
+        .with_context(|| "failed to unload module")?;
+
+    Ok(())
+}


### PR DESCRIPTION
- introduced a new optional valkey_module! preload
- unlike init which is called at the very end of valkey_module! macro this is called at the beginning and allows to stop loading module based on certain conditions
- can be used to check server_version or other args that are passed in