### PR TITLE
Adds new macro to specify enum configurations with custom option name…

### DIFF
--- a/examples/configuration.rs
+++ b/examples/configuration.rs
@@ -7,8 +7,8 @@ use lazy_static::lazy_static;
 use valkey_module::alloc::ValkeyAlloc;
 use valkey_module::{
     configuration::{ConfigurationContext, ConfigurationFlags},
-    enum_configuration, valkey_module, ConfigurationValue, Context, ValkeyError, ValkeyGILGuard,
-    ValkeyResult, ValkeyString, ValkeyValue,
+    enum_configuration, enum_configuration2, valkey_module, ConfigurationValue, Context,
+    ValkeyError, ValkeyGILGuard, ValkeyResult, ValkeyString, ValkeyValue,
 };
 
 enum_configuration! {
@@ -16,6 +16,14 @@ enum_configuration! {
     enum EnumConfiguration {
         Val1 = 1,
         Val2 = 2,
+    }
+}
+
+enum_configuration2! {
+    #[derive(PartialEq)]
+    enum EnumConfiguration2 {
+        Val1 = ("val_1", 1),
+        Val2 = ("val_2", 2),
     }
 }
 
@@ -39,6 +47,8 @@ lazy_static! {
         ValkeyGILGuard::new(EnumConfiguration::Val1);
     static ref CONFIGURATION_MUTEX_ENUM: Mutex<EnumConfiguration> =
         Mutex::new(EnumConfiguration::Val1);
+    static ref CONFIGURATION_ENUM2: ValkeyGILGuard<EnumConfiguration2> =
+        ValkeyGILGuard::new(EnumConfiguration2::Val1);
 }
 
 fn on_configuration_changed<G, T: ConfigurationValue<G>>(
@@ -133,6 +143,7 @@ valkey_module! {
             ["enum", &*CONFIGURATION_ENUM, EnumConfiguration::Val1, ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed))],
             ["reject_enum", &*CONFIGURATION_REJECT_ENUM, EnumConfiguration::Val1, ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed)), Some(Box::new(on_enum_config_set::<ValkeyString, ValkeyGILGuard<EnumConfiguration>>))],
             ["enum_mutex", &*CONFIGURATION_MUTEX_ENUM, EnumConfiguration::Val1, ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed))],
+            ["enum2", &*CONFIGURATION_ENUM2, EnumConfiguration2::Val1, ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed))],
         ],
         module_args_as_configuration: true,
     ]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -606,6 +606,10 @@ fn test_configuration() -> Result<()> {
     config_set("configuration.enum_mutex", "Val2")?;
     assert_eq!(config_get("configuration.enum_mutex")?, "Val2");
 
+    assert_eq!(config_get("configuration.enum2")?, "val_1");
+    config_set("configuration.enum2", "val_2")?;
+    assert_eq!(config_get("configuration.enum2")?, "val_2");
+
     // Validate that configs can be rejected
     let value = config_set("configuration.reject_valkey_string", "rejectvalue");
     assert!(value
@@ -632,7 +636,7 @@ fn test_configuration() -> Result<()> {
     let res: i64 = redis::cmd("configuration.num_changes")
         .query(&mut con)
         .with_context(|| "failed to run configuration.num_changes")?;
-    assert_eq!(res, 26); // the first configuration initialisation is counted as well, so we will get 22 changes.
+    assert_eq!(res, 28); // the first configuration initialisation is counted as well, so we will get 22 changes.
 
     // Validate that configs with logic to reject values can also succeed
     assert_eq!(config_get("configuration.reject_valkey_string")?, "default");
@@ -654,7 +658,7 @@ fn test_configuration() -> Result<()> {
     let res: i64 = redis::cmd("configuration.num_changes")
         .query(&mut con)
         .with_context(|| "failed to run configuration.num_changes")?;
-    assert_eq!(res, 28);
+    assert_eq!(res, 30);
 
     Ok(())
 }


### PR DESCRIPTION
… strings

This commit introduces a new macro definition called `enum_configuration2` to help with declaring a enum configuration type where the developer can specify a custom option name string in the enum option value.

Example:
```rust
enum_configuration2! {
    #[derive(PartialEq)]
    enum EnumConfiguration2 {
        Val1 = ("val_1", 1),
        Val2 = ("val_2", 2),
    }
}
```

The enum option value string accepted by the `CONFIG SET` command will be `val_1` or `val_2` instead of `Val1` or `Val2` as in when declaring the enum type with the `enum_configuration` macro.

This commit also fixes a bug in the `enum_configuration` macro, which would not allow the macro to be used twice in the same file.