### PR TITLE
added functionality to deauth and close client using ctx

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -79,6 +79,20 @@ fn get_client_ip(ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
     Ok(ctx.get_client_ip()?.into())
 }
 
+fn deauth_client_by_id(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    if args.len() != 2 {
+        return Err(ValkeyError::WrongArity);
+    }
+    let mut args = args.into_iter().skip(1);
+    let client_id_str: ValkeyString = args.next_arg()?;
+    let client_id: u64 = client_id_str.parse_integer()?.try_into().unwrap();
+    let resp = ctx.deauthenticate_and_close_client_by_id(client_id);
+    match resp {
+        Ok(msg) => Ok(ValkeyValue::from(msg)),
+        Err(err) => Err(err),
+    }
+}
+
 valkey_module! {
     name: "client",
     version: 1,
@@ -92,5 +106,6 @@ valkey_module! {
         ["client.cert", get_client_cert, "", 0, 0, 0],
         ["client.info", get_client_info, "", 0, 0, 0],
         ["client.ip", get_client_ip, "", 0, 0, 0],
+        ["client.deauth", deauth_client_by_id, "", 0, 0, 0]
     ]
 }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -93,6 +93,19 @@ fn deauth_client_by_id(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     }
 }
 
+fn config_get(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    if args.len() != 2 {
+        return Err(ValkeyError::WrongArity);
+    }
+    let mut args = args.into_iter().skip(1);
+    let config_name: ValkeyString = args.next_arg()?;
+    let config_value = ctx.config_get(config_name.to_string());
+    match config_value {
+        Ok(value) => Ok(ValkeyValue::from(value.to_string())),
+        Err(err) => Err(err),
+    }
+}
+
 valkey_module! {
     name: "client",
     version: 1,
@@ -106,6 +119,7 @@ valkey_module! {
         ["client.cert", get_client_cert, "", 0, 0, 0],
         ["client.info", get_client_info, "", 0, 0, 0],
         ["client.ip", get_client_ip, "", 0, 0, 0],
-        ["client.deauth", deauth_client_by_id, "", 0, 0, 0]
+        ["client.deauth", deauth_client_by_id, "", 0, 0, 0],
+        ["client.config_get", config_get, "", 0, 0, 0],
     ]
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1195,7 +1195,7 @@ fn test_client() -> Result<()> {
         .query(&mut con)
         .with_context(|| "failed execute client.ip")?;
     assert_eq!(resp, "127.0.0.1");
-    // Test client.deauth 
+    // Test client.deauth
     let resp: String = redis::cmd("client.deauth")
         .arg(0)
         .query(&mut con)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1199,8 +1199,13 @@ fn test_client() -> Result<()> {
     let resp: String = redis::cmd("client.deauth")
         .arg(0)
         .query(&mut con)
-        .with_context(|| "failed execute client.ip")?;
+        .with_context(|| "failed execute client.deauth")?;
     assert_eq!(resp, "Failed to deauthenticate and close client");
+    let resp: String = redis::cmd("client.config_get")
+        .arg("maxmemory-policy")
+        .query(&mut con)
+        .with_context(|| "failed execute client.config_get")?;
+    assert_eq!(resp, "noeviction");
     Ok(())
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1195,6 +1195,12 @@ fn test_client() -> Result<()> {
         .query(&mut con)
         .with_context(|| "failed execute client.ip")?;
     assert_eq!(resp, "127.0.0.1");
+    // Test client.deauth 
+    let resp: String = redis::cmd("client.deauth")
+        .arg(0)
+        .query(&mut con)
+        .with_context(|| "failed execute client.ip")?;
+    assert_eq!(resp, "Failed to deauthenticate and close client");
     Ok(())
 }
 


### PR DESCRIPTION
This PR introduces the ability to deauthenticate and close a Redis client by its ID.

✅ Changes
1. Added deauth_client_by_id command that accepts a client ID and deauthenticates/closes the client connection.
2. Introduced Context::deauthenticate_and_close_client_by_id(client_id: u64) to wrap the unsafe call to RedisModule_DeauthenticateAndCloseClient.
3. Provided a helper Context::deauthenticate_and_close_client() that uses the calling client's ID.