### PR TITLE
Add persistence event support and minor fixes

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,6 +1,6 @@
 use valkey_module::alloc::ValkeyAlloc;
 use valkey_module::{
-    valkey_module, Context, NextArg, ValkeyError, ValkeyResult, ValkeyString, ValkeyValue,
+    valkey_module, Context, NextArg, Status, ValkeyError, ValkeyResult, ValkeyString, ValkeyValue,
 };
 
 fn get_client_id(ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
@@ -88,8 +88,10 @@ fn deauth_client_by_id(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     let client_id: u64 = client_id_str.parse_integer()?.try_into().unwrap();
     let resp = ctx.deauthenticate_and_close_client_by_id(client_id);
     match resp {
-        Ok(msg) => Ok(ValkeyValue::from(msg)),
-        Err(err) => Err(err),
+        Status::Ok => Ok(ValkeyValue::from("OK")),
+        Status::Err => Err(ValkeyError::Str(
+            "Failed to deauthenticate and close client",
+        )),
     }
 }
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -79,6 +79,33 @@ fn get_client_ip(ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
     Ok(ctx.get_client_ip()?.into())
 }
 
+fn deauth_client_by_id(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    if args.len() != 2 {
+        return Err(ValkeyError::WrongArity);
+    }
+    let mut args = args.into_iter().skip(1);
+    let client_id_str: ValkeyString = args.next_arg()?;
+    let client_id: u64 = client_id_str.parse_integer()?.try_into().unwrap();
+    let resp = ctx.deauthenticate_and_close_client_by_id(client_id);
+    match resp {
+        Ok(msg) => Ok(ValkeyValue::from(msg)),
+        Err(err) => Err(err),
+    }
+}
+
+fn config_get(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    if args.len() != 2 {
+        return Err(ValkeyError::WrongArity);
+    }
+    let mut args = args.into_iter().skip(1);
+    let config_name: ValkeyString = args.next_arg()?;
+    let config_value = ctx.config_get(config_name.to_string());
+    match config_value {
+        Ok(value) => Ok(ValkeyValue::from(value.to_string())),
+        Err(err) => Err(err),
+    }
+}
+
 valkey_module! {
     name: "client",
     version: 1,
@@ -92,5 +119,7 @@ valkey_module! {
         ["client.cert", get_client_cert, "", 0, 0, 0],
         ["client.info", get_client_info, "", 0, 0, 0],
         ["client.ip", get_client_ip, "", 0, 0, 0],
+        ["client.deauth", deauth_client_by_id, "", 0, 0, 0],
+        ["client.config_get", config_get, "", 0, 0, 0],
     ]
 }

--- a/examples/server_events.rs
+++ b/examples/server_events.rs
@@ -6,7 +6,8 @@ use valkey_module::{
     server_events::FlushSubevent, valkey_module, Context, ValkeyResult, ValkeyString, ValkeyValue,
 };
 use valkey_module_macros::{
-    client_changed_event_handler, config_changed_event_handler, cron_event_handler, flush_event_handler, key_event_handler, persistence_event_handler, shutdown_event_handler
+    client_changed_event_handler, config_changed_event_handler, cron_event_handler,
+    flush_event_handler, key_event_handler, persistence_event_handler, shutdown_event_handler,
 };
 
 static NUM_FLUSHES: AtomicI64 = AtomicI64::new(0);
@@ -129,7 +130,9 @@ fn num_key_events(_ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
 }
 
 fn num_persistence_events(_ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
-    Ok(ValkeyValue::Integer(NUM_PERSISTENCE_EVENTS.load(Ordering::SeqCst)))
+    Ok(ValkeyValue::Integer(
+        NUM_PERSISTENCE_EVENTS.load(Ordering::SeqCst),
+    ))
 }
 
 //////////////////////////////////////////////////////

--- a/examples/server_events.rs
+++ b/examples/server_events.rs
@@ -1,13 +1,12 @@
 use std::sync::atomic::{AtomicI64, Ordering};
 
 use valkey_module::alloc::ValkeyAlloc;
-use valkey_module::server_events::{ClientChangeSubevent, KeyChangeSubevent};
+use valkey_module::server_events::{ClientChangeSubevent, KeyChangeSubevent, PersistenceSubevent};
 use valkey_module::{
     server_events::FlushSubevent, valkey_module, Context, ValkeyResult, ValkeyString, ValkeyValue,
 };
 use valkey_module_macros::{
-    client_changed_event_handler, config_changed_event_handler, cron_event_handler,
-    flush_event_handler, key_event_handler, shutdown_event_handler,
+    client_changed_event_handler, config_changed_event_handler, cron_event_handler, flush_event_handler, key_event_handler, persistence_event_handler, shutdown_event_handler
 };
 
 static NUM_FLUSHES: AtomicI64 = AtomicI64::new(0);
@@ -15,6 +14,7 @@ static NUM_CONNECTS: AtomicI64 = AtomicI64::new(0);
 static NUM_CRONS: AtomicI64 = AtomicI64::new(0);
 static NUM_MAX_MEMORY_CONFIGURATION_CHANGES: AtomicI64 = AtomicI64::new(0);
 static NUM_KEY_EVENTS: AtomicI64 = AtomicI64::new(0);
+static NUM_PERSISTENCE_EVENTS: AtomicI64 = AtomicI64::new(0);
 
 #[flush_event_handler]
 fn flushed_event_handler(_ctx: &Context, flush_event: FlushSubevent) {
@@ -81,6 +81,31 @@ fn shutdown_event_handler(ctx: &Context, _event: u64) {
     }
 }
 
+#[persistence_event_handler]
+fn persistence_event_handler(ctx: &Context, persistence_event: PersistenceSubevent) {
+    match persistence_event {
+        PersistenceSubevent::RdbStart => {
+            ctx.log_notice("RDB persistence started");
+        }
+        PersistenceSubevent::AofStart => {
+            ctx.log_notice("AOF persistence started");
+        }
+        PersistenceSubevent::SyncRdbStart => {
+            ctx.log_notice("Sync RDB persistence started");
+        }
+        PersistenceSubevent::SyncAofStart => {
+            ctx.log_notice("Sync AOF persistence started");
+        }
+        PersistenceSubevent::Ended => {
+            ctx.log_notice("Persistence operation ended");
+        }
+        PersistenceSubevent::Failed => {
+            ctx.log_warning("Persistence operation failed");
+        }
+    }
+    NUM_PERSISTENCE_EVENTS.fetch_add(1, Ordering::SeqCst);
+}
+
 fn num_flushed(_ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
     Ok(ValkeyValue::Integer(NUM_FLUSHES.load(Ordering::SeqCst)))
 }
@@ -103,6 +128,10 @@ fn num_key_events(_ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
     Ok(ValkeyValue::Integer(NUM_KEY_EVENTS.load(Ordering::SeqCst)))
 }
 
+fn num_persistence_events(_ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
+    Ok(ValkeyValue::Integer(NUM_PERSISTENCE_EVENTS.load(Ordering::SeqCst)))
+}
+
 //////////////////////////////////////////////////////
 
 valkey_module! {
@@ -116,5 +145,6 @@ valkey_module! {
         ["num_crons", num_crons, "readonly", 0, 0, 0],
         ["num_connects", num_connects, "readonly", 0, 0, 0],
         ["num_key_events", num_key_events, "readonly", 0, 0, 0],
+        ["num_persistence_events", num_persistence_events, "readonly", 0, 0, 0],
     ]
 }

--- a/src/context/client.rs
+++ b/src/context/client.rs
@@ -121,18 +121,14 @@ impl Context {
     pub fn get_client_ip(&self) -> ValkeyResult<String> {
         self.get_client_ip_by_id(self.get_client_id())
     }
-    pub fn deauthenticate_and_close_client_by_id(&self, client_id: u64) -> ValkeyResult<ValkeyString> {
-        match unsafe { RedisModule_DeauthenticateAndCloseClient.unwrap()(self.ctx, client_id) } {
-            result if result as isize == VALKEYMODULE_OK => Ok(ValkeyString::create(None, "OK")),
-            _ => Err(ValkeyError::Str(
-                "Failed to deauthenticate and close client",
-            )),
-        }
+    pub fn deauthenticate_and_close_client_by_id(&self, client_id: u64) -> Status {
+        let resp =
+            unsafe { RedisModule_DeauthenticateAndCloseClient.unwrap()(self.ctx, client_id) };
+        Status::from(resp)
     }
 
-    pub fn deauthenticate_and_close_client(&self) -> ValkeyResult<String> {
+    pub fn deauthenticate_and_close_client(&self) -> Status {
         self.deauthenticate_and_close_client_by_id(self.get_client_id())
-            .map(|valkey_str| valkey_str.to_string())
     }
 
     pub fn config_get(&self, config: String) -> ValkeyResult<ValkeyString> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1213,6 +1213,17 @@ fn test_client() -> Result<()> {
         .query(&mut con)
         .with_context(|| "failed execute client.ip")?;
     assert_eq!(resp, "127.0.0.1");
+    // Test client.deauth
+    let resp: String = redis::cmd("client.deauth")
+        .arg(0)
+        .query(&mut con)
+        .with_context(|| "failed execute client.deauth")?;
+    assert_eq!(resp, "Failed to deauthenticate and close client");
+    let resp: String = redis::cmd("client.config_get")
+        .arg("maxmemory-policy")
+        .query(&mut con)
+        .with_context(|| "failed execute client.config_get")?;
+    assert_eq!(resp, "noeviction");
     Ok(())
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -484,7 +484,6 @@ fn test_server_event() -> Result<()> {
     //one for overwrite and one for delete
     assert_eq!(res, 2);
 
-
     // Trigger RDB save (BGSAVE command triggers persistence events)
     redis::cmd("bgsave")
         .exec(&mut con)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -484,8 +484,6 @@ fn test_server_event() -> Result<()> {
     //one for overwrite and one for delete
     assert_eq!(res, 2);
 
-    // Get initial persistence counts
-    let initial_persistence_events: i64 = redis::cmd("num_persistence_events").query(&mut con)?;
 
     // Trigger RDB save (BGSAVE command triggers persistence events)
     redis::cmd("bgsave")
@@ -497,10 +495,10 @@ fn test_server_event() -> Result<()> {
 
     // Check that persistence events were fired
     let persistence_events_after_rdb: i64 = redis::cmd("num_persistence_events").query(&mut con)?;
-    
-    // Should have at least one more persistence event (RDB start)
-    assert!(persistence_events_after_rdb > initial_persistence_events, 
-            "Expected persistence events to increase after BGSAVE");
+
+    //initially there are 2 persistence events (one for RDB save start and one for RDB save end)
+    // after the BGSAVE command, we expect 2 more events (one for RDB save start and one for RDB save end)
+    assert_eq!(persistence_events_after_rdb, 4);
 
     Ok(())
 }
@@ -1214,11 +1212,16 @@ fn test_client() -> Result<()> {
         .with_context(|| "failed execute client.ip")?;
     assert_eq!(resp, "127.0.0.1");
     // Test client.deauth
-    let resp: String = redis::cmd("client.deauth")
-        .arg(0)
-        .query(&mut con)
-        .with_context(|| "failed execute client.deauth")?;
-    assert_eq!(resp, "Failed to deauthenticate and close client");
+    let result = redis::cmd("client.deauth").arg(0).query::<String>(&mut con);
+    match result {
+        Ok(resp) => {
+            assert_eq!(resp, "OK");
+        }
+        Err(err) => {
+            let error_msg = err.to_string();
+            assert!(error_msg.contains("Failed: to deauthenticate and close client"));
+        }
+    }
     let resp: String = redis::cmd("client.config_get")
         .arg("maxmemory-policy")
         .query(&mut con)

--- a/valkeymodule-rs-macros/src/lib.rs
+++ b/valkeymodule-rs-macros/src/lib.rs
@@ -281,6 +281,27 @@ pub fn key_event_handler(_attr: TokenStream, item: TokenStream) -> TokenStream {
     gen.into()
 }
 
+/// Proc macro which is set on a function that need to be called whenever a persistence event happened.
+/// The function must accept a [Context] and [PersistenceSubevent].
+/// Example:
+/// ```rust,no_run,ignore
+/// #[persistence_event_handler]
+/// fn persistence_event_handler(ctx: &Context, values: PersistenceSubevent) { ... }
+/// ```
+#[proc_macro_attribute]
+pub fn persistence_event_handler(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let ast: ItemFn = match syn::parse(item) {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let gen = quote! {
+        #[linkme::distributed_slice(valkey_module::server_events::PERSISTENCE_SERVER_EVENTS_LIST)]
+        #ast
+    };
+    gen.into()
+}
+
+
 
 /// The macro auto generate a [From] implementation that can convert the struct into [ValkeyValue].
 ///


### PR DESCRIPTION
1. Added support for the following persistence-related sub-events
2.  Modified deauthenticate_and_close_client_by_id() to return Status instead of ValkeyResult
3. Updated existing tests to handle the new return type for client deauthentication