### PR TITLE
Allow fetching server info with NULL context, add other server info getters

### DIFF
--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -4,8 +4,8 @@ use std::thread;
 use std::time::Duration;
 use valkey_module::alloc::ValkeyAlloc;
 use valkey_module::{
-    valkey_module, Context, NextArg, ThreadSafeContext, ValkeyGILGuard, ValkeyResult, ValkeyString,
-    ValkeyValue,
+    valkey_module, Context, NextArg, ServerInfo, ThreadSafeContext, ValkeyError, ValkeyGILGuard,
+    ValkeyResult, ValkeyString, ValkeyValue,
 };
 
 fn threads(_: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
@@ -58,6 +58,28 @@ fn get_static_data_on_thread(ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyR
     Ok(ValkeyValue::NoReply)
 }
 
+fn info_field_on_thread(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    if args.len() < 3 {
+        return Err(ValkeyError::WrongArity);
+    }
+    let mut args = args.into_iter().skip(1);
+    let section = args.next_str()?.to_owned();
+    let field = args.next_str()?.to_owned();
+
+    let blocked_client = ctx.block_client();
+    let _ = thread::spawn(move || {
+        // `ServerInfo::new` passes a NULL ctx to the Module API, so reading an
+        // INFO field from a background thread does not require acquiring the
+        // GIL via `ThreadSafeContext::lock`.
+        let value = ServerInfo::new(&section).field_c(&field).map(str::to_owned);
+
+        let thread_ctx = ThreadSafeContext::with_blocked_client(blocked_client);
+        thread_ctx.reply(Ok(value.map_or(ValkeyValue::Null, ValkeyValue::BulkString)));
+    });
+
+    Ok(ValkeyValue::NoReply)
+}
+
 //////////////////////////////////////////////////////
 
 valkey_module! {
@@ -70,5 +92,6 @@ valkey_module! {
         ["set_static_data", set_static_data, "", 0, 0, 0],
         ["get_static_data", get_static_data, "", 0, 0, 0],
         ["get_static_data_on_thread", get_static_data_on_thread, "", 0, 0, 0],
+        ["info_field_on_thread", info_field_on_thread, "", 0, 0, 0],
     ],
 }

--- a/src/context/info.rs
+++ b/src/context/info.rs
@@ -1,5 +1,5 @@
-use std::ffi::CString;
-use std::ptr::NonNull;
+use std::ffi::{CStr, CString};
+use std::ptr::{self, NonNull};
 
 use crate::Context;
 use crate::{raw, ValkeyString};
@@ -16,6 +16,27 @@ impl Drop for ServerInfo {
 }
 
 impl ServerInfo {
+    /// Creates a new `ServerInfo` without requiring a context.
+    ///
+    /// The underlying Module API permits a NULL context for both
+    /// `GetServerInfo` and `FreeServerInfo`.
+    #[must_use]
+    pub fn new(section: &str) -> Self {
+        let section = CString::new(section).unwrap();
+        let inner = unsafe {
+            raw::RedisModule_GetServerInfo.unwrap()(ptr::null_mut(), section.as_ptr())
+        };
+        Self {
+            ctx: ptr::null_mut(),
+            inner,
+        }
+    }
+
+    /// Returns a field value as a `ValkeyString`.
+    ///
+    /// This works both with and without a context. When no context is
+    /// available, the returned `ValkeyString` will not be registered with the
+    /// auto memory mechanism, but Rust's `Drop` ensures proper cleanup.
     pub fn field(&self, field: &str) -> Option<ValkeyString> {
         let field = CString::new(field).unwrap();
         let value = unsafe {
@@ -25,6 +46,76 @@ impl ServerInfo {
             None
         } else {
             Some(ValkeyString::new(NonNull::new(self.ctx), value))
+        }
+    }
+
+    /// Returns a field value as a `&str`. Does not require a context.
+    ///
+    /// The returned string borrows from the `ServerInfo` data and is valid
+    /// for the lifetime of this `ServerInfo`.
+    pub fn field_c(&self, field: &str) -> Option<&str> {
+        let field = CString::new(field).unwrap();
+        let value = unsafe {
+            raw::RedisModule_ServerInfoGetFieldC.unwrap()(self.inner, field.as_ptr())
+        };
+        if value.is_null() {
+            None
+        } else {
+            unsafe { CStr::from_ptr(value) }.to_str().ok()
+        }
+    }
+
+    /// Returns a field value as a signed integer. Does not require a context.
+    pub fn field_signed(&self, field: &str) -> Option<i64> {
+        let field = CString::new(field).unwrap();
+        let mut err: std::os::raw::c_int = 0;
+        let value = unsafe {
+            raw::RedisModule_ServerInfoGetFieldSigned.unwrap()(
+                self.inner,
+                field.as_ptr(),
+                &mut err,
+            )
+        };
+        if err != 0 {
+            None
+        } else {
+            Some(value)
+        }
+    }
+
+    /// Returns a field value as an unsigned integer. Does not require a context.
+    pub fn field_unsigned(&self, field: &str) -> Option<u64> {
+        let field = CString::new(field).unwrap();
+        let mut err: std::os::raw::c_int = 0;
+        let value = unsafe {
+            raw::RedisModule_ServerInfoGetFieldUnsigned.unwrap()(
+                self.inner,
+                field.as_ptr(),
+                &mut err,
+            )
+        };
+        if err != 0 {
+            None
+        } else {
+            Some(value)
+        }
+    }
+
+    /// Returns a field value as a double. Does not require a context.
+    pub fn field_double(&self, field: &str) -> Option<f64> {
+        let field = CString::new(field).unwrap();
+        let mut err: std::os::raw::c_int = 0;
+        let value = unsafe {
+            raw::RedisModule_ServerInfoGetFieldDouble.unwrap()(
+                self.inner,
+                field.as_ptr(),
+                &mut err,
+            )
+        };
+        if err != 0 {
+            None
+        } else {
+            Some(value)
         }
     }
 }

--- a/src/context/info.rs
+++ b/src/context/info.rs
@@ -23,9 +23,8 @@ impl ServerInfo {
     #[must_use]
     pub fn new(section: &str) -> Self {
         let section = CString::new(section).unwrap();
-        let inner = unsafe {
-            raw::RedisModule_GetServerInfo.unwrap()(ptr::null_mut(), section.as_ptr())
-        };
+        let inner =
+            unsafe { raw::RedisModule_GetServerInfo.unwrap()(ptr::null_mut(), section.as_ptr()) };
         Self {
             ctx: ptr::null_mut(),
             inner,
@@ -55,9 +54,8 @@ impl ServerInfo {
     /// for the lifetime of this `ServerInfo`.
     pub fn field_c(&self, field: &str) -> Option<&str> {
         let field = CString::new(field).unwrap();
-        let value = unsafe {
-            raw::RedisModule_ServerInfoGetFieldC.unwrap()(self.inner, field.as_ptr())
-        };
+        let value =
+            unsafe { raw::RedisModule_ServerInfoGetFieldC.unwrap()(self.inner, field.as_ptr()) };
         if value.is_null() {
             None
         } else {
@@ -70,11 +68,7 @@ impl ServerInfo {
         let field = CString::new(field).unwrap();
         let mut err: std::os::raw::c_int = 0;
         let value = unsafe {
-            raw::RedisModule_ServerInfoGetFieldSigned.unwrap()(
-                self.inner,
-                field.as_ptr(),
-                &mut err,
-            )
+            raw::RedisModule_ServerInfoGetFieldSigned.unwrap()(self.inner, field.as_ptr(), &mut err)
         };
         if err != 0 {
             None
@@ -106,11 +100,7 @@ impl ServerInfo {
         let field = CString::new(field).unwrap();
         let mut err: std::os::raw::c_int = 0;
         let value = unsafe {
-            raw::RedisModule_ServerInfoGetFieldDouble.unwrap()(
-                self.inner,
-                field.as_ptr(),
-                &mut err,
-            )
+            raw::RedisModule_ServerInfoGetFieldDouble.unwrap()(self.inner, field.as_ptr(), &mut err)
         };
         if err != 0 {
             None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub use crate::context::commands;
 pub use crate::context::keys_cursor::KeysCursor;
 pub use crate::context::server_events;
 pub use crate::context::AclPermissions;
+pub use crate::context::info::ServerInfo;
 #[cfg(all(any(
     feature = "min-valkey-compatibility-version-8-0",
     feature = "min-redis-compatibility-version-7-2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,10 +33,10 @@ pub use crate::configuration::EnumConfigurationValue;
 pub use crate::context::call_reply::FutureCallReply;
 pub use crate::context::call_reply::{CallReply, CallResult, ErrorReply, PromiseCallReply};
 pub use crate::context::commands;
+pub use crate::context::info::ServerInfo;
 pub use crate::context::keys_cursor::KeysCursor;
 pub use crate::context::server_events;
 pub use crate::context::AclPermissions;
-pub use crate::context::info::ServerInfo;
 #[cfg(all(any(
     feature = "min-valkey-compatibility-version-8-0",
     feature = "min-redis-compatibility-version-7-2"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -414,6 +414,16 @@ fn test_context_mutex() -> Result<()> {
     let res: String = redis::cmd("get_static_data_on_thread").query(&mut con)?;
     assert_eq!(&res, "foo");
 
+    let res: String = redis::cmd("info_field_on_thread")
+        .arg(&["server", "redis_version"])
+        .query(&mut con)?;
+    assert!(!res.is_empty());
+
+    let res: Option<String> = redis::cmd("info_field_on_thread")
+        .arg(&["server", "no_such_field"])
+        .query(&mut con)?;
+    assert_eq!(res, None);
+
     Ok(())
 }
 

--- a/valkeymodule-rs-macros/src/lib.rs
+++ b/valkeymodule-rs-macros/src/lib.rs
@@ -606,7 +606,6 @@ pub fn info_section(item: TokenStream) -> TokenStream {
     info_section::info_section(item)
 }
 
-
 /// Proc macro which is set on a function that need to be called whenever a replica change event happened.
 /// The function must accept a [Context] and [ReplicaChangeSubevent].
 /// Example:


### PR DESCRIPTION
My understanding of the underlying C module API is that we're allowed to make these ServerInfo calls with a null context. This should be safe in Rust, since we're already ensuring that Free is called via Drop implementations and shouldn't need to rely on auto memory management via contexts. This change would allow modules to poll server info without having to lock a context (e.g. for background metrics collection).

This change also includes access to the other server info field APIs.