### PR TITLE
[DO NOT MERGE YET]Mocking ValkeyString

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +221,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +251,21 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "gimli"
@@ -412,6 +439,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +569,32 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -752,6 +831,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +907,7 @@ dependencies = [
  "libc",
  "linkme",
  "log",
+ "mockall",
  "nix",
  "num-traits 0.2.19",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,10 @@ crate-type = ["cdylib"]
 name = "crontab"
 crate-type = ["cdylib"]
 
+[[example]]
+name = "mockvalkeystring"
+crate-type = ["cdylib"]
+
 [dependencies]
 bitflags = "2.8.0"
 libc = "0.2"
@@ -173,6 +177,7 @@ cfg-if = "1"
 valkey-module-macros-internals = { path = "valkeymodule-rs-macros-internals", version = "0.1.4"}
 log = "0.4"
 paste = "1.0.15"
+mockall = { version = "0.14.0", optional = true }
 
 [dev-dependencies]
 anyhow = "1"
@@ -183,6 +188,7 @@ valkey-module = { path = "./", default-features = false, features = ["min-valkey
 cron = "0.15.0"
 chrono = "0.4.41"
 dashmap = "6.1.0"
+mockall = "0.14.0"
 
 [build-dependencies]
 bindgen = "0.70"
@@ -199,3 +205,5 @@ min-redis-compatibility-version-6-0 = []
 enable-system-alloc = []
 # this is to indicate the Module wants to use RedisModule APIs for calls
 use-redismodule-api = []
+# enables mockall-generated MockValkeyString for unit testing without a running Valkey server
+test-mocks = ["dep:mockall"]

--- a/examples/mockvalkeystring.rs
+++ b/examples/mockvalkeystring.rs
@@ -1,0 +1,47 @@
+use valkey_module::alloc::ValkeyAlloc;
+use valkey_module::{
+    valkey_module, Context, NextArg, ValkeyError, ValkeyResult, ValkeyString,
+    ValkeyStringInterface, ValkeyValue,
+};
+
+fn mockvalkeystring_greet(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
+    let mut args = args.into_iter().skip(1);
+    let name_arg = args.next_arg()?;
+    let greeting = greet(&name_arg)?;
+    Ok(ValkeyValue::SimpleString(greeting))
+}
+
+/// Build a greeting from a ValkeyString argument.
+fn greet(name: &impl ValkeyStringInterface) -> Result<String, ValkeyError> {
+    let name_str = name.try_as_str()?;
+    Ok(format!("Hello, {name_str}!"))
+}
+
+//////////////////////////////////////////////////////
+
+valkey_module! {
+    name: "mockvalkeystring",
+    version: 1,
+    allocator: (ValkeyAlloc, ValkeyAlloc),
+    data_types: [],
+    commands: [
+        ["mockvalkeystring.greet", mockvalkeystring_greet, "", 0, 0, 0],
+    ],
+}
+
+//////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use valkey_module::MockValkeyString;
+
+    #[test]
+    fn test_greet() {
+        let mut mock = MockValkeyString::new();
+        mock.expect_try_as_str()
+            .returning(|| Ok("Alice".to_string()));
+        let result = greet(&mock).unwrap();
+        assert_eq!(result, "Hello, Alice!");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ mod context;
 pub mod key;
 pub mod logging;
 mod macros;
+pub mod redismodule_mock;
 mod utils;
 
 pub use crate::context::blocked::BlockedClient;
@@ -54,6 +55,11 @@ pub use crate::context::{
 };
 pub use crate::raw::*;
 pub use crate::redismodule::*;
+#[cfg(any(test, feature = "test-mocks"))]
+pub use crate::redismodule_mock::MockValkeyString;
+#[cfg(any(test, feature = "test-mocks"))]
+pub use crate::redismodule_mock::MockValkeyStringInterface;
+pub use crate::redismodule_mock::ValkeyStringInterface;
 use backtrace::Backtrace;
 use context::server_events::INFO_COMMAND_HANDLER_LIST;
 

--- a/src/redismodule_mock.rs
+++ b/src/redismodule_mock.rs
@@ -1,0 +1,196 @@
+use std::convert::TryFrom;
+
+use crate::rediserror::ValkeyError;
+use crate::ValkeyString;
+
+/// Mockable interface for [`ValkeyString`].
+///
+/// This trait mirrors the `ValkeyString` read/parse methods so that module
+/// command handlers can be unit-tested without a running Valkey server.
+///
+/// Methods return owned types (`String`, `Vec<u8>`) rather than references
+/// so that mockall can auto-generate the mock implementation.
+///
+/// Production code can accept `&impl ValkeyStringInterface` or use generics
+/// instead of a concrete [`ValkeyString`] to keep command logic unit-testable.
+///
+/// The corresponding `MockValkeyStringInterface` type is only exported when
+/// compiling tests or when the crate is built with the `test-mocks` feature.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use valkey_module::{ValkeyStringInterface, MockValkeyString, ValkeyResult, ValkeyValue};
+///
+/// fn greet(name: &impl ValkeyStringInterface) -> ValkeyResult {
+///     let name_str = name.try_as_str()?;
+///     Ok(ValkeyValue::SimpleString(format!("Hello, {name_str}!")))
+/// }
+///
+/// #[cfg(test)]
+/// mod tests {
+///     use super::*;
+///
+///     #[test]
+///     fn test_greet() {
+///         let mut mock = MockValkeyString::new();
+///         mock.expect_try_as_str()
+///             .returning(|| Ok("Alice".to_string()));
+///         let result = greet(&mock).unwrap();
+///     }
+/// }
+/// ```
+#[cfg_attr(any(test, feature = "test-mocks"), mockall::automock)]
+pub trait ValkeyStringInterface {
+    fn try_as_str(&self) -> Result<String, ValkeyError>;
+    fn as_slice(&self) -> Vec<u8>;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    fn to_string_lossy(&self) -> String;
+    fn parse_integer(&self) -> Result<i64, ValkeyError>;
+    fn parse_float(&self) -> Result<f64, ValkeyError>;
+    fn parse_unsigned_integer(&self) -> Result<u64, ValkeyError> {
+        let val = self.parse_integer()?;
+        u64::try_from(val)
+            .map_err(|_| ValkeyError::Str("Couldn't parse negative number as unsigned integer"))
+    }
+}
+
+impl ValkeyStringInterface for ValkeyString {
+    fn try_as_str(&self) -> Result<String, ValkeyError> {
+        ValkeyString::try_as_str(self).map(|s| s.to_string())
+    }
+
+    fn as_slice(&self) -> Vec<u8> {
+        ValkeyString::as_slice(self).to_vec()
+    }
+
+    fn len(&self) -> usize {
+        ValkeyString::len(self)
+    }
+
+    fn to_string_lossy(&self) -> String {
+        ValkeyString::to_string_lossy(self)
+    }
+
+    fn parse_integer(&self) -> Result<i64, ValkeyError> {
+        ValkeyString::parse_integer(self)
+    }
+
+    fn parse_float(&self) -> Result<f64, ValkeyError> {
+        ValkeyString::parse_float(self)
+    }
+}
+
+#[cfg(any(test, feature = "test-mocks"))]
+pub use MockValkeyStringInterface as MockValkeyString;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_try_as_str() {
+        let mut mock = MockValkeyString::new();
+        mock.expect_try_as_str()
+            .returning(|| Ok("hello".to_string()));
+        assert_eq!(mock.try_as_str().unwrap(), "hello");
+    }
+
+    #[test]
+    fn mock_as_slice() {
+        let mut mock = MockValkeyString::new();
+        mock.expect_as_slice().returning(|| b"hello".to_vec());
+        assert_eq!(mock.as_slice(), b"hello");
+    }
+
+    #[test]
+    fn mock_len() {
+        let mut mock = MockValkeyString::new();
+        mock.expect_len().returning(|| 5);
+        assert_eq!(mock.len(), 5);
+    }
+
+    #[test]
+    fn mock_is_empty() {
+        let mut mock = MockValkeyString::new();
+        mock.expect_is_empty().returning(|| true);
+        assert!(mock.is_empty());
+
+        let mut mock2 = MockValkeyString::new();
+        mock2.expect_is_empty().returning(|| false);
+        assert!(!mock2.is_empty());
+    }
+
+    #[test]
+    fn mock_to_string_lossy() {
+        let mut mock = MockValkeyString::new();
+        mock.expect_to_string_lossy()
+            .returning(|| "world".to_string());
+        assert_eq!(mock.to_string_lossy(), "world");
+    }
+
+    #[test]
+    fn mock_parse_integer() {
+        let mut mock = MockValkeyString::new();
+        mock.expect_parse_integer().returning(|| Ok(42));
+        assert_eq!(mock.parse_integer().unwrap(), 42);
+    }
+
+    #[test]
+    fn mock_parse_integer_error() {
+        let mut mock = MockValkeyString::new();
+        mock.expect_parse_integer()
+            .returning(|| Err(ValkeyError::Str("Couldn't parse as integer")));
+        assert!(mock.parse_integer().is_err());
+    }
+
+    #[test]
+    fn mock_parse_unsigned_integer() {
+        let mut mock = MockValkeyString::new();
+        mock.expect_parse_unsigned_integer().returning(|| Ok(100));
+        assert_eq!(mock.parse_unsigned_integer().unwrap(), 100);
+    }
+
+    #[test]
+    fn mock_parse_unsigned_integer_negative() {
+        let mut mock = MockValkeyString::new();
+        mock.expect_parse_unsigned_integer().returning(|| {
+            Err(ValkeyError::Str(
+                "Couldn't parse negative number as unsigned integer",
+            ))
+        });
+        assert!(mock.parse_unsigned_integer().is_err());
+    }
+
+    #[test]
+    fn mock_parse_float() {
+        let mut mock = MockValkeyString::new();
+        mock.expect_parse_float().returning(|| Ok(3.14));
+        let val = mock.parse_float().unwrap();
+        assert!((val - 3.14).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn mock_used_with_trait_bound() {
+        fn get_name(s: &impl ValkeyStringInterface) -> String {
+            s.try_as_str().unwrap().to_uppercase()
+        }
+        let mut mock = MockValkeyString::new();
+        mock.expect_try_as_str()
+            .returning(|| Ok("alice".to_string()));
+        assert_eq!(get_name(&mock), "ALICE");
+    }
+
+    #[test]
+    fn mock_with_times() {
+        let mut mock = MockValkeyString::new();
+        mock.expect_try_as_str()
+            .times(2)
+            .returning(|| Ok("test".to_string()));
+        let _ = mock.try_as_str();
+        let _ = mock.try_as_str();
+    }
+}


### PR DESCRIPTION
created ValkeyStringInterface and implemented MockValkeyString using mockall.  

Not sure I want to do this as it requires creating separate inner function to call from cmd.  
I think this PR is a better approach https://github.com/valkey-io/valkeymodule-rs/pull/226

If you try to change cmd signature to accept `args: Vec<&impl ValkeyStringInterface>` then you get errors for macro `$crate::redis_command`