### PR TITLE
implementing shim Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,19 +68,25 @@ mod tests {
     #[test]
     fn uses_test_context_and_strings_without_valkey() {
         let mut context = Context::test();
-        context.expect_get_client_id(42);
+        context
+            .expect_get_client_id(42)
+            .expect_get_server_version(8, 1, 2);
 
         let text = ValkeyString::test("hello");
         let binary = ValkeyString::test(vec![0x00, 0xff]);
+        let version = context
+            .get_server_version()
+            .expect("configured server version should be returned");
 
         assert_eq!(context.get_client_id(), 42);
+        assert_eq!((version.major, version.minor, version.patch), (8, 1, 2));
         assert_eq!(text.as_slice(), b"hello");
         assert_eq!(binary.as_slice(), &[0x00, 0xff]);
     }
 }
 ```
 
-The test context currently supports configuring client IDs, client names, client usernames, the current user, ACL-user authentication, and client deauthentication. Calls to `set_module_options` are accepted as a no-op because their effects require a running server. `Context::create_string()` also works with a test context:
+The test context currently supports configuring the server version, client IDs, client names, client usernames, the current user, ACL-user authentication, and client deauthentication. Configure `Context::get_server_version()` with `expect_get_server_version(major, minor, patch)`. Calls to `set_module_options` are accepted as a no-op because their effects require a running server. `Context::create_string()` also works with a test context:
 
 ```rust
 let context = Context::test();

--- a/README.md
+++ b/README.md
@@ -47,33 +47,46 @@ For integration tests with `ValkeyAlloc` use this:
 cargo test
 ```
 
-### Testing `ValkeyString` without a Valkey server
+### Unit testing without a Valkey server
 
-The `test-shims` feature provides `ValkeyString::test()`, which creates a binary-safe `ValkeyString` for unit tests without starting a Valkey process. Add `valkey-module` with this feature to your development dependencies, using the same version or source as your normal dependency:
+The `test-shims` feature provides `Context::test()` and `ValkeyString::test()` for unit tests that run without starting a Valkey process. Add `valkey-module` with this feature to your development dependencies, using the same version or source as your normal dependency:
 
 ```toml
 [dev-dependencies]
 valkey-module = { version = "...", features = ["test-shims"] }
 ```
 
-The feature automatically enables the system allocator required by tests. It is available only to development and test builds when configured as a dev dependency.
+The feature automatically enables the system allocator required by tests. When configured as a development dependency, the test-only APIs are available to unit tests without enabling them in production builds.
 
-`ValkeyString::test()` accepts any value implementing `Into<Vec<u8>>`, including strings and arbitrary bytes:
+Use `Context::test()` when a command handler needs a context. Its `expect_*` methods configure values returned by supported context APIs. Use `ValkeyString::test()` to construct binary-safe command arguments; it accepts any value implementing `Into<Vec<u8>>`, including strings and arbitrary bytes:
 
 ```rust
 #[cfg(test)]
 mod tests {
-    use valkey_module::ValkeyString;
+    use valkey_module::{Context, ValkeyString};
 
     #[test]
-    fn creates_strings_without_valkey() {
+    fn uses_test_context_and_strings_without_valkey() {
+        let mut context = Context::test();
+        context.expect_get_client_id(42);
+
         let text = ValkeyString::test("hello");
         let binary = ValkeyString::test(vec![0x00, 0xff]);
 
+        assert_eq!(context.get_client_id(), 42);
         assert_eq!(text.as_slice(), b"hello");
         assert_eq!(binary.as_slice(), &[0x00, 0xff]);
     }
 }
+```
+
+The test context currently supports configuring client IDs, client names, client usernames, the current user, ACL-user authentication, and client deauthentication. Calls to `set_module_options` are accepted as a no-op because their effects require a running server. `Context::create_string()` also works with a test context:
+
+```rust
+let context = Context::test();
+let value = context.create_string("hello");
+
+assert_eq!(value.as_slice(), b"hello");
 ```
 
 Run these tests normally:
@@ -82,7 +95,7 @@ Run these tests normally:
 cargo test
 ```
 
-The first call installs process-wide test callbacks for string reading, cloning, comparison, numeric parsing, retaining, and freeing. Do not enable or invoke the test shims in code running inside a Valkey process. The setup rejects installation after the real Valkey API has been initialized. APIs without a shim, such as `ValkeyString::create()` and `ValkeyString::append()`, still require a running Valkey server.
+The first call to `Context::test()` or `ValkeyString::test()` installs process-wide test callbacks. Do not invoke the test shims inside a running Valkey process; setup rejects installation after the real Valkey API has been initialized. Only explicitly shimmed APIs work without Valkey. Other APIs, including `ValkeyString::append()`, still require a running server.
 
 ### Redis Compatibility
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cargo test
 
 ### Unit testing without a Valkey server
 
-The `test-shims` feature provides `Context::test()` and `ValkeyString::test()` for unit tests that run without starting a Valkey process. Add `valkey-module` with this feature to your development dependencies, using the same version or source as your normal dependency:
+The `test-shims` feature provides `Context::test()`, `CommandFilterCtx::test()`, and `ValkeyString::test()` for unit tests that run without starting a Valkey process. Add `valkey-module` with this feature to your development dependencies, using the same version or source as your normal dependency:
 
 ```toml
 [dev-dependencies]
@@ -89,13 +89,43 @@ let value = context.create_string("hello");
 assert_eq!(value.as_slice(), b"hello");
 ```
 
+Use `CommandFilterCtx::test()` to create a `TestCommandFilterCtx` for testing command-filter logic. The test wrapper dereferences to `CommandFilterCtx`, so it can be passed directly to a helper that contains the filter behavior:
+
+```rust
+use valkey_module::CommandFilterCtx;
+
+fn rewrite_set(context: &CommandFilterCtx) {
+    if context.args_count() == 3
+        && context.cmd_get_try_as_str() == Ok("SET")
+    {
+        context.arg_replace(1, "new-key");
+    }
+}
+
+let mut context = CommandFilterCtx::test();
+context
+    .expect_args_count(3)
+    .expect_arg_get(0, "SET")
+    .expect_arg_get(1, "key")
+    .expect_arg_get(2, "value")
+    .expect_get_client_id(42);
+
+rewrite_set(&context);
+
+assert_eq!(context.args_count(), 3);
+assert_eq!(context.arg_get_try_as_str(1), Ok("new-key"));
+assert_eq!(context.get_client_id(), 42);
+```
+
+`expect_args_count()` configures the reported number of arguments, while `expect_arg_get()` configures the binary-safe value at an individual position. The test context also supports command lookup, client ID lookup, and argument replacement, insertion, and deletion. Insertions and deletions update the argument count and shift subsequent arguments.
+
 Run these tests normally:
 
 ```sh
 cargo test
 ```
 
-The first call to `Context::test()` or `ValkeyString::test()` installs process-wide test callbacks. Do not invoke the test shims inside a running Valkey process; setup rejects installation after the real Valkey API has been initialized. Only explicitly shimmed APIs work without Valkey. Other APIs, including `ValkeyString::append()`, still require a running server.
+The first call to `Context::test()`, `CommandFilterCtx::test()`, or `ValkeyString::test()` installs process-wide test callbacks. Do not invoke the test shims inside a running Valkey process; setup rejects installation after the real Valkey API has been initialized. Only explicitly shimmed APIs work without Valkey. Other APIs, including `ValkeyString::append()`, still require a running server.
 
 ### Redis Compatibility
 

--- a/examples/acl.rs
+++ b/examples/acl.rs
@@ -48,3 +48,22 @@ valkey_module! {
         ["existing_categories", existing_categories, "write", 0, 0, 0, "read fast admin"],
     ],
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_current_user() {
+        let mut context = Context::test();
+        context.expect_get_current_user("alice");
+
+        let result = get_current_user(&context, Vec::new())
+            .expect("configured current user should be returned");
+
+        assert_eq!(
+            result,
+            ValkeyValue::BulkValkeyString(ValkeyString::test("alice"))
+        );
+    }
+}

--- a/examples/call.rs
+++ b/examples/call.rs
@@ -174,3 +174,28 @@ valkey_module! {
         ["call.blocking_from_detached_ctx", call_blocking_from_detach_ctx, "", 0, 0, 0],
     ],
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_creates_string() {
+        let context = Context::test();
+        let data = "test-string";
+
+        let string = context.create_string(data);
+
+        assert_eq!(string.as_slice(), data.as_bytes());
+        assert_eq!(string.len(), data.len());
+    }
+
+    #[test]
+    fn context_creates_empty_string() {
+        let context = Context::test();
+
+        let string = context.create_string("");
+
+        assert!(string.is_empty());
+    }
+}

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -125,3 +125,55 @@ valkey_module! {
         ["client.config_get", config_get, "", 0, 0, 0]
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_client_id() {
+        let mut context = Context::test();
+        context.expect_get_client_id(42);
+
+        let result = get_client_id(&context, Vec::new()).expect("client ID should be returned");
+
+        assert_eq!(result, ValkeyValue::Integer(42));
+    }
+
+    #[test]
+    fn returns_client_name() {
+        let mut context = Context::test();
+        context.expect_get_client_name_by_id(42, "alice");
+
+        let result = get_client_name(&context, Vec::new())
+            .expect("configured client name should be returned");
+
+        assert_eq!(result, ValkeyValue::BulkString("alice".into()));
+    }
+
+    #[test]
+    fn returns_client_username() {
+        let mut context = Context::test();
+        context.expect_get_client_username_by_id(42, "alice");
+
+        let result = get_client_username(&context, Vec::new())
+            .expect("configured client username should be returned");
+
+        assert_eq!(result, ValkeyValue::BulkString("alice".into()));
+    }
+
+    #[test]
+    fn deauthenticates_client_by_id() {
+        let mut context = Context::test();
+        context.expect_deauthenticate_and_close_client_by_id(42);
+        let args = vec![
+            context.create_string("client.deauth"),
+            context.create_string("42"),
+        ];
+
+        let result = deauth_client_by_id(&context, args)
+            .expect("configured client should be deauthenticated");
+
+        assert_eq!(result, ValkeyValue::BulkString("OK".into()));
+    }
+}

--- a/examples/filter2.rs
+++ b/examples/filter2.rs
@@ -85,3 +85,26 @@ valkey_module! {
         [filter2_fn, VALKEYMODULE_CMDFILTER_NOSELF]
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authenticates_configured_acl_user() {
+        let mut context = Context::test();
+        context.expect_authenticate_client_with_acl_user("alice");
+        let username = context.create_string("alice");
+        let password = context.create_string("password");
+
+        let result = auth_callback(&context, username, password)
+            .expect("configured ACL user should authenticate");
+        let client_id = context.get_client_id();
+
+        assert_eq!(result, AUTH_HANDLED);
+        let (_, username) = CLIENT_ID_USERNAME_MAP
+            .remove(&client_id)
+            .expect("authenticated client should be tracked");
+        assert_eq!(username, "alice");
+    }
+}

--- a/examples/filter2.rs
+++ b/examples/filter2.rs
@@ -58,13 +58,17 @@ fn filter1_fn(ctx: *mut RedisModuleCommandFilterCtx) {
     // registered via valkey_module! macro
     // making sure that two modules can have the same filter fn name
     let cf_ctx = CommandFilterCtx::new(ctx);
+    let _username = filter_username(&cf_ctx);
+    // do something with the username
+}
+
+fn filter_username(cf_ctx: &CommandFilterCtx) -> String {
     let client_id = cf_ctx.get_client_id();
     // lookup username by client_id
-    let _username = match CLIENT_ID_USERNAME_MAP.get(&client_id) {
+    match CLIENT_ID_USERNAME_MAP.get(&client_id) {
         Some(tmp) => tmp.clone(),
         None => "default".to_string(),
-    };
-    // do something with the username
+    }
 }
 
 fn filter2_fn(_ctx: *mut RedisModuleCommandFilterCtx) {
@@ -106,5 +110,25 @@ mod tests {
             .remove(&client_id)
             .expect("authenticated client should be tracked");
         assert_eq!(username, "alice");
+    }
+
+    #[test]
+    fn returns_username_for_command_filter_client() {
+        let client_id = 42;
+        CLIENT_ID_USERNAME_MAP.insert(client_id, "alice".to_string());
+        let mut context = CommandFilterCtx::test();
+        context.expect_get_client_id(client_id);
+
+        assert_eq!(filter_username(&context), "alice");
+
+        CLIENT_ID_USERNAME_MAP.remove(&client_id);
+    }
+
+    #[test]
+    fn defaults_username_for_unknown_command_filter_client() {
+        let mut context = CommandFilterCtx::test();
+        context.expect_get_client_id(99);
+
+        assert_eq!(filter_username(&context), "default");
     }
 }

--- a/examples/preload.rs
+++ b/examples/preload.rs
@@ -21,3 +21,17 @@ valkey_module! {
     preload: preload,
     commands: [],
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_configured_server_version() {
+        let mut context = Context::test();
+        context.expect_get_server_version(8, 1, 2);
+        let args = [ValkeyString::test("arg1")];
+
+        assert_eq!(preload(&context, &args), Status::Ok);
+    }
+}

--- a/examples/server_events.rs
+++ b/examples/server_events.rs
@@ -341,3 +341,15 @@ valkey_module! {
         ["num_event_loop_after_sleep", num_event_loop_after_sleep, "readonly", 0, 0, 0],
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initializes_with_module_options_in_test_context() {
+        let context = Context::test();
+
+        assert_eq!(init(&context, &[]), Status::Ok);
+    }
+}

--- a/examples/test_helper.rs
+++ b/examples/test_helper.rs
@@ -58,3 +58,27 @@ valkey_module! {
         ["test_helper.err", test_helper_err, "", 0, 0, 0],
     ],
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use valkey_module::ValkeyValue;
+
+    #[test]
+    fn returns_server_version_from_test_context() {
+        let mut context = Context::test();
+        context.expect_get_server_version(8, 1, 2);
+
+        let result = test_helper_version(&context, Vec::new())
+            .expect("configured server version should be returned");
+
+        assert_eq!(
+            result,
+            ValkeyValue::Array(vec![
+                ValkeyValue::Integer(8),
+                ValkeyValue::Integer(1),
+                ValkeyValue::Integer(2),
+            ])
+        );
+    }
+}

--- a/src/test-shims/command_filter_ctx.rs
+++ b/src/test-shims/command_filter_ctx.rs
@@ -1,0 +1,460 @@
+use crate::{raw, CommandFilterCtx, ValkeyString};
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::ptr::null_mut;
+
+const DEFAULT_CLIENT_ID: u64 = 1;
+
+impl CommandFilterCtx {
+    /// Creates a test command-filter context whose API return values can be configured.
+    #[must_use]
+    pub fn test() -> TestCommandFilterCtx {
+        TestCommandFilterCtx::new()
+    }
+}
+
+struct CommandFilterData {
+    args_count: libc::c_int,
+    args: HashMap<libc::c_int, ValkeyString>,
+    client_id: u64,
+}
+
+impl Default for CommandFilterData {
+    fn default() -> Self {
+        Self {
+            args_count: 0,
+            args: HashMap::new(),
+            client_id: DEFAULT_CLIENT_ID,
+        }
+    }
+}
+
+/// Owns a test-only [`CommandFilterCtx`] that can be used without a running Valkey server.
+pub struct TestCommandFilterCtx {
+    context: CommandFilterCtx,
+    data: Box<CommandFilterData>,
+}
+
+impl TestCommandFilterCtx {
+    fn new() -> Self {
+        super::setup_test_shims();
+
+        let mut data = Box::<CommandFilterData>::default();
+        let inner =
+            (data.as_mut() as *mut CommandFilterData).cast::<raw::RedisModuleCommandFilterCtx>();
+
+        Self {
+            context: CommandFilterCtx::new(inner),
+            data,
+        }
+    }
+
+    /// Configures the value returned by [`CommandFilterCtx::args_count`].
+    pub fn expect_args_count(&mut self, args_count: libc::c_int) -> &mut Self {
+        self.data.args_count = args_count;
+        self
+    }
+
+    /// Configures the value returned by [`CommandFilterCtx::arg_get`] for `position`.
+    pub fn expect_arg_get<T: Into<Vec<u8>>>(
+        &mut self,
+        position: libc::c_int,
+        argument: T,
+    ) -> &mut Self {
+        self.data
+            .args
+            .insert(position, ValkeyString::test(argument));
+        self
+    }
+
+    /// Configures the value returned by [`CommandFilterCtx::get_client_id`].
+    pub fn expect_get_client_id(&mut self, client_id: u64) -> &mut Self {
+        self.data.client_id = client_id;
+        self
+    }
+}
+
+impl Deref for TestCommandFilterCtx {
+    type Target = CommandFilterCtx;
+
+    fn deref(&self) -> &Self::Target {
+        &self.context
+    }
+}
+
+pub(super) extern "C" fn command_filter_args_count(
+    ctx: *mut raw::RedisModuleCommandFilterCtx,
+) -> libc::c_int {
+    if ctx.is_null() {
+        return 0;
+    }
+
+    // SAFETY: `TestCommandFilterCtx::new` stores a live `CommandFilterData` allocation at this
+    // opaque pointer.
+    unsafe { &*ctx.cast::<CommandFilterData>() }.args_count
+}
+
+pub(super) extern "C" fn command_filter_arg_get(
+    ctx: *mut raw::RedisModuleCommandFilterCtx,
+    position: libc::c_int,
+) -> *mut raw::RedisModuleString {
+    if ctx.is_null() || position < 0 {
+        return null_mut();
+    }
+
+    // SAFETY: `TestCommandFilterCtx::new` stores a live `CommandFilterData` allocation at this
+    // opaque pointer.
+    let data = unsafe { &*ctx.cast::<CommandFilterData>() };
+    data.args
+        .get(&position)
+        .map_or(null_mut(), |argument| argument.inner)
+}
+
+pub(super) extern "C" fn command_filter_arg_replace(
+    ctx: *mut raw::RedisModuleCommandFilterCtx,
+    position: libc::c_int,
+    argument: *mut raw::RedisModuleString,
+) -> libc::c_int {
+    if argument.is_null() {
+        return raw::Status::Err as libc::c_int;
+    }
+
+    // `CommandFilterCtx::arg_replace` transfers one retained reference to the callback. Taking
+    // ownership here ensures that reference is released even when the replacement is rejected.
+    let argument = ValkeyString::from_redis_module_string(null_mut(), argument);
+    if ctx.is_null() || position < 0 {
+        return raw::Status::Err as libc::c_int;
+    }
+
+    // SAFETY: `TestCommandFilterCtx::new` stores a live, uniquely owned `CommandFilterData`
+    // allocation at this opaque pointer. Command-filter callbacks execute synchronously.
+    let data = unsafe { &mut *ctx.cast::<CommandFilterData>() };
+    let Some(current_argument) = data.args.get_mut(&position) else {
+        return raw::Status::Err as libc::c_int;
+    };
+
+    *current_argument = argument;
+    raw::Status::Ok as libc::c_int
+}
+
+pub(super) extern "C" fn command_filter_arg_insert(
+    ctx: *mut raw::RedisModuleCommandFilterCtx,
+    position: libc::c_int,
+    argument: *mut raw::RedisModuleString,
+) -> libc::c_int {
+    if argument.is_null() {
+        return raw::Status::Err as libc::c_int;
+    }
+
+    // `CommandFilterCtx::arg_insert` transfers one retained reference to the callback. Taking
+    // ownership here ensures that reference is released even when the insertion is rejected.
+    let argument = ValkeyString::from_redis_module_string(null_mut(), argument);
+    if ctx.is_null() || position < 0 {
+        return raw::Status::Err as libc::c_int;
+    }
+
+    // SAFETY: `TestCommandFilterCtx::new` stores a live, uniquely owned `CommandFilterData`
+    // allocation at this opaque pointer. Command-filter callbacks execute synchronously.
+    let data = unsafe { &mut *ctx.cast::<CommandFilterData>() };
+    if data.args_count < 0 || position > data.args_count || data.args_count == libc::c_int::MAX {
+        return raw::Status::Err as libc::c_int;
+    }
+
+    for current_position in (position..data.args_count).rev() {
+        if let Some(current_argument) = data.args.remove(&current_position) {
+            data.args.insert(current_position + 1, current_argument);
+        }
+    }
+    data.args.insert(position, argument);
+    data.args_count += 1;
+
+    raw::Status::Ok as libc::c_int
+}
+
+pub(super) extern "C" fn command_filter_arg_delete(
+    ctx: *mut raw::RedisModuleCommandFilterCtx,
+    position: libc::c_int,
+) -> libc::c_int {
+    if ctx.is_null() || position < 0 {
+        return raw::Status::Err as libc::c_int;
+    }
+
+    // SAFETY: `TestCommandFilterCtx::new` stores a live, uniquely owned `CommandFilterData`
+    // allocation at this opaque pointer. Command-filter callbacks execute synchronously.
+    let data = unsafe { &mut *ctx.cast::<CommandFilterData>() };
+    if position >= data.args_count {
+        return raw::Status::Err as libc::c_int;
+    }
+
+    data.args.remove(&position);
+    for current_position in position + 1..data.args_count {
+        if let Some(current_argument) = data.args.remove(&current_position) {
+            data.args.insert(current_position - 1, current_argument);
+        }
+    }
+    data.args_count -= 1;
+
+    raw::Status::Ok as libc::c_int
+}
+
+pub(super) extern "C" fn command_filter_get_client_id(
+    ctx: *mut raw::RedisModuleCommandFilterCtx,
+) -> libc::c_ulonglong {
+    if ctx.is_null() {
+        return DEFAULT_CLIENT_ID;
+    }
+
+    // SAFETY: `TestCommandFilterCtx::new` stores a live `CommandFilterData` allocation at this
+    // opaque pointer.
+    unsafe { &*ctx.cast::<CommandFilterData>() }.client_id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_configured_args_count() {
+        let mut context = CommandFilterCtx::test();
+        context.expect_args_count(3);
+
+        assert_eq!(context.args_count(), 3);
+    }
+
+    #[test]
+    fn defaults_args_count_to_zero() {
+        let context = CommandFilterCtx::test();
+
+        assert_eq!(context.args_count(), 0);
+    }
+
+    #[test]
+    fn replaces_configured_args_count() {
+        let mut context = CommandFilterCtx::test();
+        context.expect_args_count(1).expect_args_count(4);
+
+        assert_eq!(context.args_count(), 4);
+    }
+
+    #[test]
+    fn returns_zero_for_null_context() {
+        assert_eq!(command_filter_args_count(null_mut()), 0);
+    }
+
+    #[test]
+    fn returns_configured_argument() {
+        let mut context = CommandFilterCtx::test();
+        context.expect_arg_get(1, "value");
+
+        assert_eq!(
+            context
+                .arg_get_try_as_str(1)
+                .expect("configured argument should be valid UTF-8"),
+            "value"
+        );
+    }
+
+    #[test]
+    fn returns_configured_command() {
+        let mut context = CommandFilterCtx::test();
+        context.expect_arg_get(0, "set");
+
+        assert_eq!(
+            context
+                .cmd_get_try_as_str()
+                .expect("configured command should be valid UTF-8"),
+            "set"
+        );
+    }
+
+    #[test]
+    fn replaces_configured_argument() {
+        let mut context = CommandFilterCtx::test();
+        context.expect_arg_get(1, "old").expect_arg_get(1, "new");
+
+        assert_eq!(
+            context
+                .arg_get_try_as_str(1)
+                .expect("replacement argument should be valid UTF-8"),
+            "new"
+        );
+    }
+
+    #[test]
+    fn returns_null_for_unconfigured_or_negative_position() {
+        let context = CommandFilterCtx::test();
+
+        assert!(context.arg_get(0).is_null());
+        assert!(context.arg_get(-1).is_null());
+    }
+
+    #[test]
+    fn returns_null_argument_for_null_context() {
+        assert!(command_filter_arg_get(null_mut(), 0).is_null());
+    }
+
+    #[test]
+    fn replaces_argument() {
+        let mut context = CommandFilterCtx::test();
+        context.expect_arg_get(1, "old");
+
+        context.arg_replace(1, "new");
+
+        assert_eq!(
+            context
+                .arg_get_try_as_str(1)
+                .expect("replacement argument should be valid UTF-8"),
+            "new"
+        );
+    }
+
+    #[test]
+    fn rejects_null_argument_or_context() {
+        assert_eq!(
+            command_filter_arg_replace(null_mut(), 0, null_mut()),
+            raw::Status::Err as libc::c_int
+        );
+
+        let argument = ValkeyString::create_and_retain("new");
+        assert_eq!(
+            command_filter_arg_replace(null_mut(), 0, argument.inner),
+            raw::Status::Err as libc::c_int
+        );
+    }
+
+    #[test]
+    fn inserts_argument_and_shifts_later_arguments() {
+        let mut context = CommandFilterCtx::test();
+        context
+            .expect_args_count(3)
+            .expect_arg_get(0, "set")
+            .expect_arg_get(1, "key")
+            .expect_arg_get(2, "value");
+
+        context.arg_insert(1, "new-key");
+
+        assert_eq!(context.args_count(), 4);
+        assert_eq!(context.cmd_get_try_as_str(), Ok("set"));
+        assert_eq!(context.arg_get_try_as_str(1), Ok("new-key"));
+        assert_eq!(context.arg_get_try_as_str(2), Ok("key"));
+        assert_eq!(context.arg_get_try_as_str(3), Ok("value"));
+    }
+
+    #[test]
+    fn appends_argument_at_args_count() {
+        let mut context = CommandFilterCtx::test();
+        context.expect_args_count(1).expect_arg_get(0, "command");
+
+        context.arg_insert(1, "argument");
+
+        assert_eq!(context.args_count(), 2);
+        assert_eq!(context.arg_get_try_as_str(1), Ok("argument"));
+    }
+
+    #[test]
+    fn rejects_insert_outside_argument_bounds() {
+        let mut context = CommandFilterCtx::test();
+        context.expect_args_count(1).expect_arg_get(0, "command");
+
+        context.arg_insert(2, "argument");
+        context.arg_insert(-1, "argument");
+
+        assert_eq!(context.args_count(), 1);
+        assert!(context.arg_get(1).is_null());
+    }
+
+    #[test]
+    fn rejects_insert_with_null_argument_or_context() {
+        assert_eq!(
+            command_filter_arg_insert(null_mut(), 0, null_mut()),
+            raw::Status::Err as libc::c_int
+        );
+
+        let argument = ValkeyString::create_and_retain("new");
+        assert_eq!(
+            command_filter_arg_insert(null_mut(), 0, argument.inner),
+            raw::Status::Err as libc::c_int
+        );
+    }
+
+    #[test]
+    fn deletes_argument_and_shifts_later_arguments() {
+        let mut context = CommandFilterCtx::test();
+        context
+            .expect_args_count(4)
+            .expect_arg_get(0, "set")
+            .expect_arg_get(1, "old-key")
+            .expect_arg_get(2, "new-key")
+            .expect_arg_get(3, "value");
+
+        context.arg_delete(1);
+
+        assert_eq!(context.args_count(), 3);
+        assert_eq!(context.cmd_get_try_as_str(), Ok("set"));
+        assert_eq!(context.arg_get_try_as_str(1), Ok("new-key"));
+        assert_eq!(context.arg_get_try_as_str(2), Ok("value"));
+        assert!(context.arg_get(3).is_null());
+    }
+
+    #[test]
+    fn deletes_command_and_shifts_arguments() {
+        let mut context = CommandFilterCtx::test();
+        context
+            .expect_args_count(2)
+            .expect_arg_get(0, "command")
+            .expect_arg_get(1, "argument");
+
+        context.arg_delete(0);
+
+        assert_eq!(context.args_count(), 1);
+        assert_eq!(context.cmd_get_try_as_str(), Ok("argument"));
+    }
+
+    #[test]
+    fn rejects_delete_outside_argument_bounds() {
+        let mut context = CommandFilterCtx::test();
+        context.expect_args_count(1).expect_arg_get(0, "command");
+
+        context.arg_delete(1);
+        context.arg_delete(-1);
+
+        assert_eq!(context.args_count(), 1);
+        assert_eq!(context.cmd_get_try_as_str(), Ok("command"));
+    }
+
+    #[test]
+    fn rejects_delete_with_null_context() {
+        assert_eq!(
+            command_filter_arg_delete(null_mut(), 0),
+            raw::Status::Err as libc::c_int
+        );
+    }
+
+    #[test]
+    fn returns_configured_client_id() {
+        let mut context = CommandFilterCtx::test();
+        context.expect_get_client_id(42);
+
+        assert_eq!(context.get_client_id(), 42);
+    }
+
+    #[test]
+    fn defaults_client_id_when_no_expectation_is_configured() {
+        let context = CommandFilterCtx::test();
+
+        assert_eq!(context.get_client_id(), DEFAULT_CLIENT_ID);
+    }
+
+    #[test]
+    fn replaces_configured_client_id() {
+        let mut context = CommandFilterCtx::test();
+        context.expect_get_client_id(10).expect_get_client_id(20);
+
+        assert_eq!(context.get_client_id(), 20);
+    }
+
+    #[test]
+    fn defaults_client_id_for_null_context() {
+        assert_eq!(command_filter_get_client_id(null_mut()), DEFAULT_CLIENT_ID);
+    }
+}

--- a/src/test-shims/context.rs
+++ b/src/test-shims/context.rs
@@ -1,8 +1,11 @@
 use crate::{raw, Context, ValkeyString};
 use std::ops::Deref;
 use std::ptr::null_mut;
+use std::sync::atomic::{AtomicI32, Ordering};
 
 const DEFAULT_CLIENT_ID: u64 = 1;
+
+static SERVER_VERSION: AtomicI32 = AtomicI32::new(0);
 
 impl Context {
     /// Creates a test context whose API return values can be configured with `expect_*` methods.
@@ -21,6 +24,19 @@ struct ContextData {
     deauthentication_expected: bool,
 }
 
+impl Default for ContextData {
+    fn default() -> Self {
+        Self {
+            client_id: DEFAULT_CLIENT_ID,
+            client_name: None,
+            client_username: None,
+            current_user: None,
+            acl_user: None,
+            deauthentication_expected: false,
+        }
+    }
+}
+
 /// Owns a test-only [`Context`] that can be used without a running Valkey server.
 pub struct TestContext {
     context: Context,
@@ -31,14 +47,7 @@ impl TestContext {
     fn new() -> Self {
         super::setup_test_shims();
 
-        let mut data = Box::new(ContextData {
-            client_id: DEFAULT_CLIENT_ID,
-            client_name: None,
-            client_username: None,
-            current_user: None,
-            acl_user: None,
-            deauthentication_expected: false,
-        });
+        let mut data = Box::new(ContextData::default());
         let ctx = (data.as_mut() as *mut ContextData).cast::<raw::RedisModuleCtx>();
 
         Self {
@@ -78,6 +87,15 @@ impl TestContext {
     /// Configures the username returned by [`Context::get_current_user`].
     pub fn expect_get_current_user<T: Into<Vec<u8>>>(&mut self, current_user: T) -> &mut Self {
         self.data.current_user = Some(current_user.into());
+        self
+    }
+
+    /// Configures the server version returned by the test shim.
+    pub fn expect_get_server_version(&mut self, major: u8, minor: u8, patch: u8) -> &mut Self {
+        let version = (libc::c_int::from(major) << 16)
+            | (libc::c_int::from(minor) << 8)
+            | libc::c_int::from(patch);
+        SERVER_VERSION.store(version, Ordering::Relaxed);
         self
     }
 
@@ -190,6 +208,10 @@ pub(super) extern "C" fn deauthenticate_and_close_client(
 
 /// Accepts module options in tests without applying server-wide behavior.
 pub(super) extern "C" fn set_module_options(_ctx: *mut raw::RedisModuleCtx, _options: libc::c_int) {
+}
+
+pub(super) extern "C" fn get_server_version() -> libc::c_int {
+    SERVER_VERSION.load(Ordering::Relaxed)
 }
 
 pub(super) extern "C" fn authenticate_client_with_acl_user(
@@ -319,6 +341,23 @@ mod tests {
         context.expect_get_current_user("alice");
 
         assert_eq!(context.get_current_user().as_slice(), b"alice");
+    }
+
+    #[test]
+    fn returns_configured_server_version() {
+        let mut context = Context::test();
+        context.expect_get_server_version(8, 1, 2);
+
+        assert_eq!(
+            context
+                .get_server_version()
+                .expect("configured server version should be returned"),
+            raw::Version {
+                major: 8,
+                minor: 1,
+                patch: 2,
+            }
+        );
     }
 
     #[test]

--- a/src/test-shims/context.rs
+++ b/src/test-shims/context.rs
@@ -1,0 +1,472 @@
+use crate::{raw, Context, ValkeyString};
+use std::ops::Deref;
+use std::ptr::null_mut;
+
+const DEFAULT_CLIENT_ID: u64 = 1;
+
+impl Context {
+    /// Creates a test context whose API return values can be configured with `expect_*` methods.
+    #[must_use]
+    pub fn test() -> TestContext {
+        TestContext::new()
+    }
+}
+
+struct ContextData {
+    client_id: u64,
+    client_name: Option<Vec<u8>>,
+    client_username: Option<Vec<u8>>,
+    current_user: Option<Vec<u8>>,
+    acl_user: Option<Vec<u8>>,
+    deauthentication_expected: bool,
+}
+
+/// Owns a test-only [`Context`] that can be used without a running Valkey server.
+pub struct TestContext {
+    context: Context,
+    data: Box<ContextData>,
+}
+
+impl TestContext {
+    fn new() -> Self {
+        super::setup_test_shims();
+
+        let mut data = Box::new(ContextData {
+            client_id: DEFAULT_CLIENT_ID,
+            client_name: None,
+            client_username: None,
+            current_user: None,
+            acl_user: None,
+            deauthentication_expected: false,
+        });
+        let ctx = (data.as_mut() as *mut ContextData).cast::<raw::RedisModuleCtx>();
+
+        Self {
+            context: Context::new(ctx),
+            data,
+        }
+    }
+
+    /// Configures the value returned by [`Context::get_client_id`].
+    pub fn expect_get_client_id(&mut self, client_id: u64) -> &mut Self {
+        self.data.client_id = client_id;
+        self
+    }
+
+    /// Configures the current client ID and the name returned for that ID.
+    pub fn expect_get_client_name_by_id<T: Into<Vec<u8>>>(
+        &mut self,
+        client_id: u64,
+        client_name: T,
+    ) -> &mut Self {
+        self.data.client_id = client_id;
+        self.data.client_name = Some(client_name.into());
+        self
+    }
+
+    /// Configures the current client ID and the username returned for that ID.
+    pub fn expect_get_client_username_by_id<T: Into<Vec<u8>>>(
+        &mut self,
+        client_id: u64,
+        client_username: T,
+    ) -> &mut Self {
+        self.data.client_id = client_id;
+        self.data.client_username = Some(client_username.into());
+        self
+    }
+
+    /// Configures the username returned by [`Context::get_current_user`].
+    pub fn expect_get_current_user<T: Into<Vec<u8>>>(&mut self, current_user: T) -> &mut Self {
+        self.data.current_user = Some(current_user.into());
+        self
+    }
+
+    /// Configures the ACL username accepted by [`Context::authenticate_client_with_acl_user`].
+    pub fn expect_authenticate_client_with_acl_user<T: Into<Vec<u8>>>(
+        &mut self,
+        username: T,
+    ) -> &mut Self {
+        self.data.acl_user = Some(username.into());
+        self
+    }
+
+    /// Configures the client ID accepted by [`Context::deauthenticate_and_close_client_by_id`].
+    pub fn expect_deauthenticate_and_close_client_by_id(&mut self, client_id: u64) -> &mut Self {
+        self.data.client_id = client_id;
+        self.data.deauthentication_expected = true;
+        self
+    }
+}
+
+impl Deref for TestContext {
+    type Target = Context;
+
+    fn deref(&self) -> &Self::Target {
+        &self.context
+    }
+}
+
+pub(super) extern "C" fn get_client_id(ctx: *mut raw::RedisModuleCtx) -> libc::c_ulonglong {
+    if ctx.is_null() {
+        return DEFAULT_CLIENT_ID;
+    }
+
+    // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
+    unsafe { &*ctx.cast::<ContextData>() }.client_id
+}
+
+pub(super) extern "C" fn get_client_name_by_id(
+    ctx: *mut raw::RedisModuleCtx,
+    client_id: libc::c_ulonglong,
+) -> *mut raw::RedisModuleString {
+    if ctx.is_null() {
+        return null_mut();
+    }
+
+    // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
+    let data = unsafe { &*ctx.cast::<ContextData>() };
+    if data.client_id != client_id {
+        return null_mut();
+    }
+    let Some(client_name) = data.client_name.as_ref() else {
+        return null_mut();
+    };
+
+    ValkeyString::test(client_name.clone()).take()
+}
+
+pub(super) extern "C" fn get_client_username_by_id(
+    ctx: *mut raw::RedisModuleCtx,
+    client_id: libc::c_ulonglong,
+) -> *mut raw::RedisModuleString {
+    if ctx.is_null() {
+        return null_mut();
+    }
+
+    // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
+    let data = unsafe { &*ctx.cast::<ContextData>() };
+    if data.client_id != client_id {
+        return null_mut();
+    }
+    let Some(client_username) = data.client_username.as_ref() else {
+        return null_mut();
+    };
+
+    ValkeyString::test(client_username.clone()).take()
+}
+
+pub(super) extern "C" fn get_current_user_name(
+    ctx: *mut raw::RedisModuleCtx,
+) -> *mut raw::RedisModuleString {
+    if ctx.is_null() {
+        return null_mut();
+    }
+
+    // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
+    let data = unsafe { &*ctx.cast::<ContextData>() };
+    let Some(current_user) = data.current_user.as_ref() else {
+        return null_mut();
+    };
+
+    ValkeyString::test(current_user.clone()).take()
+}
+
+pub(super) extern "C" fn deauthenticate_and_close_client(
+    ctx: *mut raw::RedisModuleCtx,
+    client_id: libc::c_ulonglong,
+) -> libc::c_int {
+    if ctx.is_null() {
+        return raw::Status::Err as libc::c_int;
+    }
+
+    // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
+    let data = unsafe { &*ctx.cast::<ContextData>() };
+    if data.deauthentication_expected && data.client_id == client_id {
+        raw::Status::Ok as libc::c_int
+    } else {
+        raw::Status::Err as libc::c_int
+    }
+}
+
+/// Accepts module options in tests without applying server-wide behavior.
+pub(super) extern "C" fn set_module_options(_ctx: *mut raw::RedisModuleCtx, _options: libc::c_int) {
+}
+
+pub(super) extern "C" fn authenticate_client_with_acl_user(
+    ctx: *mut raw::RedisModuleCtx,
+    name: *const libc::c_char,
+    len: usize,
+    _callback: raw::RedisModuleUserChangedFunc,
+    _privdata: *mut libc::c_void,
+    client_id: *mut u64,
+) -> libc::c_int {
+    if ctx.is_null() || name.is_null() {
+        return raw::Status::Err as libc::c_int;
+    }
+
+    // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
+    let data = unsafe { &*ctx.cast::<ContextData>() };
+    // SAFETY: The callback contract requires `name` to reference at least `len` readable bytes.
+    let name = unsafe { std::slice::from_raw_parts(name.cast::<u8>(), len) };
+    if data.acl_user.as_deref() != Some(name) {
+        return raw::Status::Err as libc::c_int;
+    }
+
+    if !client_id.is_null() {
+        // SAFETY: A non-null `client_id` points to writable storage supplied by the caller.
+        unsafe {
+            *client_id = data.client_id;
+        }
+    }
+
+    raw::Status::Ok as libc::c_int
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_configured_client_id() {
+        let mut context = Context::test();
+        context.expect_get_client_id(42);
+
+        assert_eq!(context.get_client_id(), 42);
+    }
+
+    #[test]
+    fn defaults_client_id_when_no_expectation_is_configured() {
+        let context = Context::test();
+
+        assert_eq!(context.get_client_id(), 1);
+    }
+
+    #[test]
+    fn replaces_configured_client_id() {
+        let mut context = Context::test();
+        context.expect_get_client_id(10).expect_get_client_id(20);
+
+        assert_eq!(context.get_client_id(), 20);
+    }
+
+    #[test]
+    fn returns_configured_client_name_by_id() {
+        let mut context = Context::test();
+        context.expect_get_client_name_by_id(42, "alice");
+
+        let client_name = context
+            .get_client_name_by_id(42)
+            .expect("configured client name should be returned");
+
+        assert_eq!(client_name.as_slice(), b"alice");
+    }
+
+    #[test]
+    fn rejects_unconfigured_client_id() {
+        let mut context = Context::test();
+        context.expect_get_client_name_by_id(42, "alice");
+
+        assert!(context.get_client_name_by_id(7).is_err());
+    }
+
+    #[test]
+    fn returns_current_client_name() {
+        let mut context = Context::test();
+        context.expect_get_client_name_by_id(42, "alice");
+
+        let client_name = context
+            .get_client_name()
+            .expect("current client name should be returned");
+
+        assert_eq!(client_name.as_slice(), b"alice");
+    }
+
+    #[test]
+    fn returns_configured_client_username_by_id() {
+        let mut context = Context::test();
+        context.expect_get_client_username_by_id(42, "alice");
+
+        let client_username = context
+            .get_client_username_by_id(42)
+            .expect("configured client username should be returned");
+
+        assert_eq!(client_username.as_slice(), b"alice");
+    }
+
+    #[test]
+    fn rejects_unconfigured_username_client_id() {
+        let mut context = Context::test();
+        context.expect_get_client_username_by_id(42, "alice");
+
+        assert!(context.get_client_username_by_id(7).is_err());
+    }
+
+    #[test]
+    fn returns_current_client_username() {
+        let mut context = Context::test();
+        context.expect_get_client_username_by_id(42, "alice");
+
+        let client_username = context
+            .get_client_username()
+            .expect("current client username should be returned");
+
+        assert_eq!(client_username.as_slice(), b"alice");
+    }
+
+    #[test]
+    fn returns_configured_current_user() {
+        let mut context = Context::test();
+        context.expect_get_current_user("alice");
+
+        assert_eq!(context.get_current_user().as_slice(), b"alice");
+    }
+
+    #[test]
+    fn authenticates_configured_acl_user() {
+        let mut context = Context::test();
+        context.expect_authenticate_client_with_acl_user("alice");
+        let username = context.create_string("alice");
+
+        assert_eq!(
+            context.authenticate_client_with_acl_user(&username),
+            raw::Status::Ok
+        );
+    }
+
+    #[test]
+    fn rejects_unconfigured_or_mismatched_acl_user() {
+        let context = Context::test();
+        let username = context.create_string("alice");
+
+        assert_eq!(
+            context.authenticate_client_with_acl_user(&username),
+            raw::Status::Err
+        );
+
+        let mut context = Context::test();
+        context.expect_authenticate_client_with_acl_user("bob");
+
+        assert_eq!(
+            context.authenticate_client_with_acl_user(&username),
+            raw::Status::Err
+        );
+    }
+
+    #[test]
+    fn writes_client_id_for_configured_acl_user() {
+        let mut context = Context::test();
+        context
+            .expect_get_client_id(42)
+            .expect_authenticate_client_with_acl_user("alice");
+        let username = context.create_string("alice");
+        let mut client_id = 0;
+
+        let status = authenticate_client_with_acl_user(
+            context.get_raw(),
+            username.as_ptr().cast::<libc::c_char>(),
+            username.len(),
+            None,
+            null_mut(),
+            &mut client_id,
+        );
+
+        assert_eq!(status, raw::Status::Ok as libc::c_int);
+        assert_eq!(client_id, 42);
+    }
+
+    #[test]
+    fn rejects_acl_authentication_with_null_context_or_name() {
+        assert_eq!(
+            authenticate_client_with_acl_user(
+                null_mut(),
+                std::ptr::null(),
+                0,
+                None,
+                null_mut(),
+                null_mut(),
+            ),
+            raw::Status::Err as libc::c_int
+        );
+
+        let context = Context::test();
+        assert_eq!(
+            authenticate_client_with_acl_user(
+                context.get_raw(),
+                std::ptr::null(),
+                0,
+                None,
+                null_mut(),
+                null_mut(),
+            ),
+            raw::Status::Err as libc::c_int
+        );
+    }
+
+    #[test]
+    fn rejects_current_user_with_null_context() {
+        assert!(get_current_user_name(null_mut()).is_null());
+    }
+
+    #[test]
+    fn deauthenticates_configured_client_by_id() {
+        let mut context = Context::test();
+        context.expect_deauthenticate_and_close_client_by_id(42);
+
+        assert_eq!(
+            context.deauthenticate_and_close_client_by_id(42),
+            raw::Status::Ok
+        );
+    }
+
+    #[test]
+    fn deauthenticates_current_client() {
+        let mut context = Context::test();
+        context.expect_deauthenticate_and_close_client_by_id(42);
+
+        assert_eq!(context.deauthenticate_and_close_client(), raw::Status::Ok);
+    }
+
+    #[test]
+    fn rejects_unconfigured_client_deauthentication() {
+        let mut context = Context::test();
+        context.expect_deauthenticate_and_close_client_by_id(42);
+
+        assert_eq!(
+            context.deauthenticate_and_close_client_by_id(7),
+            raw::Status::Err
+        );
+    }
+
+    #[test]
+    fn requires_deauthentication_expectation() {
+        let context = Context::test();
+
+        assert_eq!(
+            context.deauthenticate_and_close_client_by_id(DEFAULT_CLIENT_ID),
+            raw::Status::Err
+        );
+    }
+
+    #[test]
+    fn rejects_deauthentication_with_null_context() {
+        assert_eq!(
+            deauthenticate_and_close_client(null_mut(), 42),
+            raw::Status::Err as libc::c_int
+        );
+    }
+
+    #[test]
+    fn accepts_all_module_options() {
+        let context = Context::test();
+        let module_options = vec![
+            raw::ModuleOptions::HANDLE_IO_ERRORS,
+            raw::ModuleOptions::NO_IMPLICIT_SIGNAL_MODIFIED,
+            raw::ModuleOptions::HANDLE_REPL_ASYNC_LOAD,
+            raw::ModuleOptions::ALLOW_NESTED_KEYSPACE_NOTIFICATIONS,
+        ];
+
+        for options in module_options {
+            context.set_module_options(options);
+        }
+    }
+}

--- a/src/test-shims/mod.rs
+++ b/src/test-shims/mod.rs
@@ -1,4 +1,7 @@
+mod context;
 mod valkey_string;
+
+pub use context::TestContext;
 
 use crate::raw;
 use std::ptr::addr_of;
@@ -14,15 +17,27 @@ fn setup_test_shims() {
         );
 
         unsafe {
+            // ValkeyString
             raw::RedisModule_StringPtrLen = Some(valkey_string::string_ptr_len);
             raw::RedisModule_FreeString = Some(valkey_string::free_string);
             raw::RedisModule_RetainString = Some(valkey_string::retain_string);
             raw::RedisModule_StringToLongLong = Some(valkey_string::string_to_longlong);
             raw::RedisModule_StringToULongLong = Some(valkey_string::string_to_ulonglong);
             raw::RedisModule_StringToDouble = Some(valkey_string::string_to_double);
+            raw::RedisModule_CreateString = Some(valkey_string::create_string);
             raw::RedisModule_CreateStringFromString =
                 Some(valkey_string::create_string_from_string);
             raw::RedisModule_StringCompare = Some(valkey_string::string_compare);
+            // context
+            raw::RedisModule_GetClientId = Some(context::get_client_id);
+            raw::RedisModule_GetClientNameById = Some(context::get_client_name_by_id);
+            raw::RedisModule_GetClientUserNameById = Some(context::get_client_username_by_id);
+            raw::RedisModule_GetCurrentUserName = Some(context::get_current_user_name);
+            raw::RedisModule_DeauthenticateAndCloseClient =
+                Some(context::deauthenticate_and_close_client);
+            raw::RedisModule_SetModuleOptions = Some(context::set_module_options);
+            raw::RedisModule_AuthenticateClientWithACLUser =
+                Some(context::authenticate_client_with_acl_user);
         }
     });
 }

--- a/src/test-shims/mod.rs
+++ b/src/test-shims/mod.rs
@@ -38,6 +38,7 @@ fn setup_test_shims() {
             raw::RedisModule_DeauthenticateAndCloseClient =
                 Some(context::deauthenticate_and_close_client);
             raw::RedisModule_SetModuleOptions = Some(context::set_module_options);
+            raw::RedisModule_GetServerVersion = Some(context::get_server_version);
             raw::RedisModule_AuthenticateClientWithACLUser =
                 Some(context::authenticate_client_with_acl_user);
             // CommandFilterCtx

--- a/src/test-shims/mod.rs
+++ b/src/test-shims/mod.rs
@@ -1,6 +1,8 @@
+mod command_filter_ctx;
 mod context;
 mod valkey_string;
 
+pub use command_filter_ctx::TestCommandFilterCtx;
 pub use context::TestContext;
 
 use crate::raw;
@@ -28,7 +30,7 @@ fn setup_test_shims() {
             raw::RedisModule_CreateStringFromString =
                 Some(valkey_string::create_string_from_string);
             raw::RedisModule_StringCompare = Some(valkey_string::string_compare);
-            // context
+            // Context
             raw::RedisModule_GetClientId = Some(context::get_client_id);
             raw::RedisModule_GetClientNameById = Some(context::get_client_name_by_id);
             raw::RedisModule_GetClientUserNameById = Some(context::get_client_username_by_id);
@@ -38,6 +40,18 @@ fn setup_test_shims() {
             raw::RedisModule_SetModuleOptions = Some(context::set_module_options);
             raw::RedisModule_AuthenticateClientWithACLUser =
                 Some(context::authenticate_client_with_acl_user);
+            // CommandFilterCtx
+            raw::RedisModule_CommandFilterArgsCount =
+                Some(command_filter_ctx::command_filter_args_count);
+            raw::RedisModule_CommandFilterArgGet = Some(command_filter_ctx::command_filter_arg_get);
+            raw::RedisModule_CommandFilterArgReplace =
+                Some(command_filter_ctx::command_filter_arg_replace);
+            raw::RedisModule_CommandFilterArgInsert =
+                Some(command_filter_ctx::command_filter_arg_insert);
+            raw::RedisModule_CommandFilterArgDelete =
+                Some(command_filter_ctx::command_filter_arg_delete);
+            raw::RedisModule_CommandFilterGetClientId =
+                Some(command_filter_ctx::command_filter_get_client_id);
         }
     });
 }

--- a/src/test-shims/valkey_string.rs
+++ b/src/test-shims/valkey_string.rs
@@ -97,6 +97,25 @@ pub(super) extern "C" fn string_to_double(
     parse_string(string, value)
 }
 
+/// Creates a shim-backed module string by copying `len` bytes from `ptr`.
+pub(super) extern "C" fn create_string(
+    _ctx: *mut raw::RedisModuleCtx,
+    ptr: *const c_char,
+    len: usize,
+) -> *mut raw::RedisModuleString {
+    if ptr.is_null() {
+        return if len == 0 {
+            into_raw_string(Vec::new())
+        } else {
+            null_mut()
+        };
+    }
+
+    // SAFETY: The callback contract requires `ptr` to reference at least `len` readable bytes.
+    let data = unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), len) };
+    into_raw_string(data.to_vec())
+}
+
 /// Creates an independently owned copy of a shim-backed module string.
 ///
 /// This models `RedisModule_CreateStringFromString`, which creates a new string rather than
@@ -188,6 +207,38 @@ mod tests {
         let string = ValkeyString::test(bytes.clone());
 
         assert_eq!(string.as_slice(), bytes);
+    }
+
+    #[test]
+    fn context_creates_string() {
+        let context = crate::Context::test();
+        let data = "é日";
+        let string = context.create_string(data);
+
+        assert_eq!(string.as_slice(), data.as_bytes());
+        assert_eq!(string.len(), data.len());
+    }
+
+    #[test]
+    fn create_string_copies_binary_input() {
+        let data = [0x00, 0xff, b'a'];
+        let inner = create_string(null_mut(), data.as_ptr().cast::<c_char>(), data.len());
+        let string = ValkeyString::from_redis_module_string(null_mut(), inner);
+
+        assert_eq!(string.as_slice(), data);
+    }
+
+    #[test]
+    fn create_string_accepts_null_for_empty_input() {
+        let inner = create_string(null_mut(), std::ptr::null(), 0);
+        let string = ValkeyString::from_redis_module_string(null_mut(), inner);
+
+        assert!(string.is_empty());
+    }
+
+    #[test]
+    fn create_string_rejects_null_for_nonempty_input() {
+        assert!(create_string(null_mut(), std::ptr::null(), 1).is_null());
     }
 
     #[test]


### PR DESCRIPTION
  - Add Context::test() for unit testing module code without running a Valkey server, with
    configurable expectations for client, ACL, string-creation, module-option, and
    deauthentication APIs.

  - Add CommandFilterCtx::test() with configurable arguments and client IDs, including
    support for argument lookup, replacement, insertion, deletion, count updates, and safe
    string ownership.

  - Add get_server_version support to the test context through expect_get_server_version(),
    simplify context initialization with ContextData::default(), and test preload/version
    handlers.