### PR TITLE
updating test-shims for context

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -224,4 +224,25 @@ mod tests {
             Err(ValkeyError::Str("Client/Cert is null"))
         ));
     }
+
+    #[test]
+    fn sets_client_name() {
+        let mut context = Context::test();
+        context.expect_set_client_name_by_id(42);
+        let args = vec![
+            context.create_string("client.set_name"),
+            context.create_string("bob"),
+        ];
+
+        let result = set_client_name(&context, args).expect("client name should be updated");
+
+        assert_eq!(result, ValkeyValue::Integer(Status::Ok as i64));
+        assert_eq!(
+            context
+                .get_client_name()
+                .expect("updated client name should be returned")
+                .as_slice(),
+            b"bob"
+        );
+    }
 }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,7 +1,6 @@
 use valkey_module::alloc::ValkeyAlloc;
 use valkey_module::{
-    valkey_module, Context, NextArg, RedisModuleClientInfo, Status, ValkeyError, ValkeyResult,
-    ValkeyString, ValkeyValue,
+    valkey_module, Context, NextArg, Status, ValkeyError, ValkeyResult, ValkeyString, ValkeyValue,
 };
 
 fn get_client_id(ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
@@ -125,6 +124,7 @@ valkey_module! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use valkey_module::RedisModuleClientInfo;
 
     const TEST_CLIENT_CERTIFICATE: &str = concat!(
         "-----BEGIN CERTIFICATE-----\n",

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -192,4 +192,15 @@ mod tests {
 
         assert_eq!(result, ValkeyValue::BulkString("7".into()));
     }
+
+    #[test]
+    fn returns_client_ip() {
+        let mut context = Context::test();
+        context.expect_get_client_ip_by_id(42, "127.0.0.1");
+
+        let result =
+            get_client_ip(&context, Vec::new()).expect("configured client IP should be returned");
+
+        assert_eq!(result, ValkeyValue::BulkString("127.0.0.1".into()));
+    }
 }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -49,12 +49,7 @@ fn set_client_name(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
 }
 
 fn get_client_cert(ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
-    // unless connection is made with cert, this will return Err, so just log it and return nothing
-    match ctx.get_client_cert() {
-        Ok(tmp) => ctx.log_notice(&format!("client_cert: {:?}", tmp.to_string())),
-        Err(err) => ctx.log_notice(&format!("client_cert: {:?}", err.to_string())),
-    }
-    Ok("".into())
+    Ok(ctx.get_client_cert()?.to_string().into())
 }
 
 fn get_client_info(ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
@@ -131,6 +126,12 @@ valkey_module! {
 mod tests {
     use super::*;
 
+    const TEST_CLIENT_CERTIFICATE: &str = concat!(
+        "-----BEGIN CERTIFICATE-----\n",
+        "VGhpcyBpcyBhIHRlc3QgY2xpZW50IGNlcnRpZmljYXRlLg==\n",
+        "-----END CERTIFICATE-----\n"
+    );
+
     #[test]
     fn returns_client_id() {
         let mut context = Context::test();
@@ -202,5 +203,25 @@ mod tests {
             get_client_ip(&context, Vec::new()).expect("configured client IP should be returned");
 
         assert_eq!(result, ValkeyValue::BulkString("127.0.0.1".into()));
+    }
+
+    #[test]
+    fn handles_configured_client_certificate() {
+        let mut context = Context::test();
+        context.expect_get_client_cert(TEST_CLIENT_CERTIFICATE);
+
+        let result = get_client_cert(&context, Vec::new())
+            .expect("configured client certificate should be handled");
+
+        assert_eq!(
+            result,
+            ValkeyValue::BulkString(TEST_CLIENT_CERTIFICATE.into())
+        );
+
+        let context = Context::test();
+        assert!(matches!(
+            get_client_cert(&context, Vec::new()),
+            Err(ValkeyError::Str("Client/Cert is null"))
+        ));
     }
 }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,6 +1,7 @@
 use valkey_module::alloc::ValkeyAlloc;
 use valkey_module::{
-    valkey_module, Context, NextArg, Status, ValkeyError, ValkeyResult, ValkeyString, ValkeyValue,
+    valkey_module, Context, NextArg, RedisModuleClientInfo, Status, ValkeyError, ValkeyResult,
+    ValkeyString, ValkeyValue,
 };
 
 fn get_client_id(ctx: &Context, _args: Vec<ValkeyString>) -> ValkeyResult {
@@ -175,5 +176,20 @@ mod tests {
             .expect("configured client should be deauthenticated");
 
         assert_eq!(result, ValkeyValue::BulkString("OK".into()));
+    }
+
+    #[test]
+    fn returns_client_info_version() {
+        let mut context = Context::test();
+        context.expect_get_client_info_by_id(RedisModuleClientInfo {
+            version: 7,
+            id: 42,
+            ..RedisModuleClientInfo::default()
+        });
+
+        let result = get_client_info(&context, Vec::new())
+            .expect("configured client info should be returned");
+
+        assert_eq!(result, ValkeyValue::BulkString("7".into()));
     }
 }

--- a/src/context/client.rs
+++ b/src/context/client.rs
@@ -304,4 +304,21 @@ mod tests {
             Err(ValkeyError::Str("Client/Cert is null"))
         ));
     }
+
+    #[test]
+    fn sets_client_name_by_id_and_rejects_unknown_client_id() {
+        let mut context = Context::test();
+        context.expect_set_client_name_by_id(42);
+        let client_name = context.create_string("bob");
+
+        assert_eq!(context.set_client_name_by_id(42, &client_name), Status::Ok);
+        assert_eq!(
+            context
+                .get_client_name_by_id(42)
+                .expect("updated client name should be returned")
+                .as_slice(),
+            b"bob"
+        );
+        assert_eq!(context.set_client_name_by_id(7, &client_name), Status::Err);
+    }
 }

--- a/src/context/client.rs
+++ b/src/context/client.rs
@@ -255,4 +255,27 @@ mod tests {
         assert_eq!(client_info.port, 0);
         assert_eq!(client_info.db, 0);
     }
+
+    #[test]
+    fn gets_configured_client_ip_and_rejects_unknown_client_id() {
+        let mut context = Context::test();
+        context.expect_get_client_ip_by_id(42, "127.0.0.1");
+
+        assert_eq!(
+            context
+                .get_client_ip()
+                .expect("configured client IP should be returned"),
+            "127.0.0.1"
+        );
+        assert_eq!(
+            context
+                .get_client_ip_by_id(42)
+                .expect("configured client IP should be returned by ID"),
+            "127.0.0.1"
+        );
+        assert!(matches!(
+            context.get_client_ip_by_id(7),
+            Err(ValkeyError::Str("Client/Info not found"))
+        ));
+    }
 }

--- a/src/context/client.rs
+++ b/src/context/client.rs
@@ -171,13 +171,6 @@ mod tests {
                 .as_slice(),
             b"alice"
         );
-        assert_eq!(
-            context
-                .get_client_name_by_id(42)
-                .expect("configured client name should be returned by ID")
-                .as_slice(),
-            b"alice"
-        );
         assert!(matches!(
             context.get_client_name_by_id(7),
             Err(ValkeyError::Str("Client/Client name is null"))
@@ -193,13 +186,6 @@ mod tests {
             context
                 .get_client_username()
                 .expect("configured client username should be returned")
-                .as_slice(),
-            b"alice"
-        );
-        assert_eq!(
-            context
-                .get_client_username_by_id(42)
-                .expect("configured client username should be returned by ID")
                 .as_slice(),
             b"alice"
         );
@@ -237,13 +223,8 @@ mod tests {
         };
         context.expect_get_client_info_by_id(client_info);
 
-        let result = context
-            .get_client_info()
-            .expect("configured client info should be returned");
-        assert_eq!(result.id, 42);
-        assert_eq!(result.addr, client_info.addr);
-        assert_eq!(result.port, 6379);
-        assert_eq!(result.db, 2);
+        assert!(context.get_client_info().is_ok());
+        assert!(context.get_client_info_by_id(42).is_ok());
         assert!(matches!(
             context.get_client_info_by_id(7),
             Err(ValkeyError::Str("Client/Info not found"))
@@ -273,16 +254,19 @@ mod tests {
                 .expect("configured client IP should be returned"),
             "127.0.0.1"
         );
-        assert_eq!(
-            context
-                .get_client_ip_by_id(42)
-                .expect("configured client IP should be returned by ID"),
-            "127.0.0.1"
-        );
         assert!(matches!(
             context.get_client_ip_by_id(7),
             Err(ValkeyError::Str("Client/Info not found"))
         ));
+
+        context.expect_get_client_ip_by_id(42, "2001:db8::1");
+
+        assert_eq!(
+            context
+                .get_client_ip()
+                .expect("configured IPv6 client IP should be returned"),
+            "2001:db8::1"
+        );
     }
 
     #[test]
@@ -306,19 +290,12 @@ mod tests {
     }
 
     #[test]
-    fn sets_client_name_by_id_and_rejects_unknown_client_id() {
+    fn sets_current_client_name_and_rejects_unknown_client_id() {
         let mut context = Context::test();
         context.expect_set_client_name_by_id(42);
         let client_name = context.create_string("bob");
 
-        assert_eq!(context.set_client_name_by_id(42, &client_name), Status::Ok);
-        assert_eq!(
-            context
-                .get_client_name_by_id(42)
-                .expect("updated client name should be returned")
-                .as_slice(),
-            b"bob"
-        );
+        assert_eq!(context.set_client_name(&client_name), Status::Ok);
         assert_eq!(context.set_client_name_by_id(7, &client_name), Status::Err);
     }
 }

--- a/src/context/client.rs
+++ b/src/context/client.rs
@@ -7,8 +7,8 @@ use crate::{
 use std::ffi::CStr;
 use std::os::raw::c_void;
 
-impl RedisModuleClientInfo {
-    fn new() -> Self {
+impl Default for RedisModuleClientInfo {
+    fn default() -> Self {
         Self {
             version: 1,
             flags: 0,
@@ -91,13 +91,12 @@ impl Context {
 
     /// wrapper for RedisModule_GetClientInfoById
     pub fn get_client_info_by_id(&self, client_id: u64) -> ValkeyResult<RedisModuleClientInfo> {
-        let mut mci = RedisModuleClientInfo::new();
+        let mut mci = RedisModuleClientInfo::default();
         let mci_ptr: *mut c_void = &mut mci as *mut _ as *mut c_void;
-        unsafe {
-            RedisModule_GetClientInfoById.unwrap()(mci_ptr, client_id);
-        };
-        if mci_ptr.is_null() {
-            Err(ValkeyError::Str("Client/Info is null"))
+        let status: Status =
+            unsafe { RedisModule_GetClientInfoById.unwrap()(mci_ptr, client_id).into() };
+        if status != Status::Ok {
+            Err(ValkeyError::Str("Client/Info not found"))
         } else {
             Ok(mci)
         }
@@ -218,5 +217,42 @@ mod tests {
             context.deauthenticate_and_close_client_by_id(7),
             Status::Err
         );
+    }
+
+    #[test]
+    fn gets_configured_client_info_and_rejects_unknown_client_id() {
+        let mut context = Context::test();
+        let client_info = RedisModuleClientInfo {
+            id: 42,
+            addr: [1; 46],
+            port: 6379,
+            db: 2,
+            ..RedisModuleClientInfo::default()
+        };
+        context.expect_get_client_info_by_id(42, client_info);
+
+        let result = context
+            .get_client_info()
+            .expect("configured client info should be returned");
+        assert_eq!(result.id, 42);
+        assert_eq!(result.addr, client_info.addr);
+        assert_eq!(result.port, 6379);
+        assert_eq!(result.db, 2);
+        assert!(matches!(
+            context.get_client_info_by_id(7),
+            Err(ValkeyError::Str("Client/Info not found"))
+        ));
+    }
+
+    #[test]
+    fn client_info_default_uses_version_one_and_zeroed_fields() {
+        let client_info = RedisModuleClientInfo::default();
+
+        assert_eq!(client_info.version, 1);
+        assert_eq!(client_info.flags, 0);
+        assert_eq!(client_info.id, 0);
+        assert_eq!(client_info.addr, [0; 46]);
+        assert_eq!(client_info.port, 0);
+        assert_eq!(client_info.db, 0);
     }
 }

--- a/src/context/client.rs
+++ b/src/context/client.rs
@@ -229,7 +229,7 @@ mod tests {
             db: 2,
             ..RedisModuleClientInfo::default()
         };
-        context.expect_get_client_info_by_id(42, client_info);
+        context.expect_get_client_info_by_id(client_info);
 
         let result = context
             .get_client_info()

--- a/src/context/client.rs
+++ b/src/context/client.rs
@@ -145,6 +145,12 @@ impl Context {
 mod tests {
     use super::*;
 
+    const TEST_CLIENT_CERTIFICATE: &str = concat!(
+        "-----BEGIN CERTIFICATE-----\n",
+        "VGhpcyBpcyBhIHRlc3QgY2xpZW50IGNlcnRpZmljYXRlLg==\n",
+        "-----END CERTIFICATE-----\n"
+    );
+
     #[test]
     fn returns_current_client_id() {
         let mut context = Context::test();
@@ -276,6 +282,26 @@ mod tests {
         assert!(matches!(
             context.get_client_ip_by_id(7),
             Err(ValkeyError::Str("Client/Info not found"))
+        ));
+    }
+
+    #[test]
+    fn gets_configured_client_certificate_and_rejects_missing_certificate() {
+        let mut context = Context::test();
+        context.expect_get_client_cert(TEST_CLIENT_CERTIFICATE);
+
+        assert_eq!(
+            context
+                .get_client_cert()
+                .expect("configured client certificate should be returned")
+                .as_slice(),
+            TEST_CLIENT_CERTIFICATE.as_bytes()
+        );
+
+        let context = Context::test();
+        assert!(matches!(
+            context.get_client_cert(),
+            Err(ValkeyError::Str("Client/Cert is null"))
         ));
     }
 }

--- a/src/context/client.rs
+++ b/src/context/client.rs
@@ -141,3 +141,82 @@ impl Context {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_current_client_id() {
+        let mut context = Context::test();
+        context.expect_get_client_id(42);
+
+        assert_eq!(context.get_client_id(), 42);
+    }
+
+    #[test]
+    fn gets_client_name_and_rejects_unknown_client_id() {
+        let mut context = Context::test();
+        context.expect_get_client_name_by_id(42, "alice");
+
+        assert_eq!(
+            context
+                .get_client_name()
+                .expect("configured client name should be returned")
+                .as_slice(),
+            b"alice"
+        );
+        assert_eq!(
+            context
+                .get_client_name_by_id(42)
+                .expect("configured client name should be returned by ID")
+                .as_slice(),
+            b"alice"
+        );
+        assert!(matches!(
+            context.get_client_name_by_id(7),
+            Err(ValkeyError::Str("Client/Client name is null"))
+        ));
+    }
+
+    #[test]
+    fn gets_client_username_and_rejects_unknown_client_id() {
+        let mut context = Context::test();
+        context.expect_get_client_username_by_id(42, "alice");
+
+        assert_eq!(
+            context
+                .get_client_username()
+                .expect("configured client username should be returned")
+                .as_slice(),
+            b"alice"
+        );
+        assert_eq!(
+            context
+                .get_client_username_by_id(42)
+                .expect("configured client username should be returned by ID")
+                .as_slice(),
+            b"alice"
+        );
+        assert!(matches!(
+            context.get_client_username_by_id(7),
+            Err(ValkeyError::Str("Client/Username is null"))
+        ));
+    }
+
+    #[test]
+    fn deauthenticates_configured_client_id_and_rejects_unknown_client_id() {
+        let mut context = Context::test();
+        context.expect_deauthenticate_and_close_client_by_id(42);
+
+        assert_eq!(context.deauthenticate_and_close_client(), Status::Ok);
+        assert_eq!(
+            context.deauthenticate_and_close_client_by_id(42),
+            Status::Ok
+        );
+        assert_eq!(
+            context.deauthenticate_and_close_client_by_id(7),
+            Status::Err
+        );
+    }
+}

--- a/src/redismodule.rs
+++ b/src/redismodule.rs
@@ -432,3 +432,200 @@ impl Drop for RedisBuffer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_clone_keeps_string_alive_after_original_is_dropped() {
+        let context = Context::test();
+        let original = ValkeyString::test("value");
+        let cloned = original.safe_clone(&context);
+
+        assert_eq!(cloned.inner, original.inner);
+        drop(original);
+
+        assert_eq!(cloned.as_slice(), b"value");
+    }
+
+    #[test]
+    fn create_and_retain_keeps_the_transferred_reference_alive() {
+        let _context = Context::test();
+        let string = ValkeyString::create_and_retain("value");
+        let inner = string.inner;
+
+        assert_eq!(string.as_slice(), b"value");
+        drop(string);
+
+        // SAFETY: `create_and_retain` creates a second shim-backed reference for the caller to
+        // transfer to Valkey. This releases that reference after the test's owner was dropped.
+        unsafe {
+            raw::RedisModule_FreeString.unwrap()(ptr::null_mut(), inner);
+        }
+    }
+
+    #[test]
+    fn create_from_slice_preserves_binary_data() {
+        let _context = Context::test();
+        let string = ValkeyString::create_from_slice(ptr::null_mut(), &[0, 0xff, b'a']);
+
+        assert_eq!(string.as_slice(), &[0, 0xff, b'a']);
+    }
+
+    #[test]
+    fn empty_string_is_empty() {
+        let string = ValkeyString::test("");
+
+        assert!(string.is_empty());
+    }
+
+    #[test]
+    fn invalid_utf8_reports_an_error_and_converts_lossily() {
+        let string = ValkeyString::test([b'a', 0xff]);
+
+        assert!(matches!(
+            string.try_as_str(),
+            Err(ValkeyError::Str("Couldn't parse as UTF-8 string"))
+        ));
+        assert_eq!(string.to_string_lossy(), "a�");
+    }
+
+    #[test]
+    fn parses_signed_integer_boundaries() {
+        let minimum = ValkeyString::test(i64::MIN.to_string());
+        let maximum = ValkeyString::test(i64::MAX.to_string());
+
+        assert_eq!(
+            minimum
+                .parse_integer()
+                .expect("minimum signed integer should parse"),
+            i64::MIN
+        );
+        assert_eq!(
+            maximum
+                .parse_integer()
+                .expect("maximum signed integer should parse"),
+            i64::MAX
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_signed_and_unsigned_integers() {
+        let signed_overflow = ValkeyString::test("9223372036854775808");
+        let negative_unsigned = ValkeyString::test("-1");
+        let unsigned_overflow = ValkeyString::test("18446744073709551616");
+
+        assert!(matches!(
+            signed_overflow.parse_integer(),
+            Err(ValkeyError::Str("Couldn't parse as integer"))
+        ));
+        assert!(matches!(
+            negative_unsigned.parse_unsigned_integer(),
+            Err(ValkeyError::Str("Couldn't parse as unsigned integer"))
+        ));
+        assert!(matches!(
+            unsigned_overflow.parse_unsigned_integer(),
+            Err(ValkeyError::Str("Couldn't parse as unsigned integer"))
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_float() {
+        let string = ValkeyString::test("not-a-float");
+
+        assert!(matches!(
+            string.parse_float(),
+            Err(ValkeyError::Str("Couldn't parse as float"))
+        ));
+    }
+
+    #[test]
+    fn next_arg_helpers_consume_values_of_each_supported_type() {
+        let mut args = vec![
+            ValkeyString::test([0, 0xff]),
+            ValkeyString::test("string"),
+            ValkeyString::test("text"),
+            ValkeyString::test("-42"),
+            ValkeyString::test(u64::MAX.to_string()),
+            ValkeyString::test("42.5"),
+        ]
+        .into_iter();
+
+        assert_eq!(
+            args.next_arg()
+                .expect("binary argument should be returned")
+                .as_slice(),
+            &[0, 0xff]
+        );
+        assert_eq!(
+            args.next_string()
+                .expect("string argument should be returned"),
+            "string"
+        );
+        assert!(args.next_str().is_ok());
+        assert_eq!(args.next_i64().expect("integer should parse"), -42);
+        assert_eq!(
+            args.next_u64().expect("unsigned integer should parse"),
+            u64::MAX
+        );
+        assert_eq!(args.next_f64().expect("float should parse"), 42.5);
+        assert!(args.done().is_ok());
+    }
+
+    #[test]
+    fn next_arg_helpers_report_wrong_arity_for_empty_iterator() {
+        let mut args = Vec::<ValkeyString>::new().into_iter();
+
+        assert!(matches!(args.next_arg(), Err(ValkeyError::WrongArity)));
+        assert!(matches!(args.next_string(), Err(ValkeyError::WrongArity)));
+        assert!(matches!(args.next_str(), Err(ValkeyError::WrongArity)));
+        assert!(matches!(args.next_i64(), Err(ValkeyError::WrongArity)));
+        assert!(matches!(args.next_u64(), Err(ValkeyError::WrongArity)));
+        assert!(matches!(args.next_f64(), Err(ValkeyError::WrongArity)));
+    }
+
+    #[test]
+    fn next_str_rejects_invalid_utf8_while_next_string_is_lossy() {
+        let mut string_args = vec![ValkeyString::test([b'a', 0xff])].into_iter();
+        let mut str_args = vec![ValkeyString::test([b'a', 0xff])].into_iter();
+
+        assert_eq!(
+            string_args
+                .next_string()
+                .expect("next_string should use a lossy conversion"),
+            "a�"
+        );
+        assert!(matches!(
+            str_args.next_str(),
+            Err(ValkeyError::Str("Couldn't parse as UTF-8 string"))
+        ));
+    }
+
+    #[test]
+    fn numeric_next_arg_helpers_report_parse_errors() {
+        let mut integer_args = vec![ValkeyString::test("not-an-integer")].into_iter();
+        let mut unsigned_args = vec![ValkeyString::test("-1")].into_iter();
+        let mut float_args = vec![ValkeyString::test("not-a-float")].into_iter();
+
+        assert!(matches!(
+            integer_args.next_i64(),
+            Err(ValkeyError::Str("Couldn't parse as integer"))
+        ));
+        assert!(matches!(
+            unsigned_args.next_u64(),
+            Err(ValkeyError::Str("Couldn't parse as unsigned integer"))
+        ));
+        assert!(matches!(
+            float_args.next_f64(),
+            Err(ValkeyError::Str("Couldn't parse as float"))
+        ));
+    }
+
+    #[test]
+    fn done_rejects_remaining_arguments() {
+        let mut args = vec![ValkeyString::test("extra")].into_iter();
+
+        assert!(matches!(args.done(), Err(ValkeyError::WrongArity)));
+    }
+}

--- a/src/test-shims/context.rs
+++ b/src/test-shims/context.rs
@@ -25,6 +25,7 @@ struct ContextData {
     client_id: u64,
     client_name: Option<Vec<u8>>,
     client_username: Option<Vec<u8>>,
+    client_cert: Option<Vec<u8>>,
     current_user: Option<Vec<u8>>,
     acl_user: Option<Vec<u8>>,
     deauthentication_expected: bool,
@@ -36,6 +37,7 @@ impl Default for ContextData {
             client_id: DEFAULT_CLIENT_ID,
             client_name: None,
             client_username: None,
+            client_cert: None,
             current_user: None,
             acl_user: None,
             deauthentication_expected: false,
@@ -92,6 +94,12 @@ impl TestContext {
     ) -> &mut Self {
         self.data.client_id = client_id;
         self.data.client_username = Some(client_username.into());
+        self
+    }
+
+    /// Configures the certificate returned for the current client.
+    pub fn expect_get_client_cert<T: Into<Vec<u8>>>(&mut self, client_cert: T) -> &mut Self {
+        self.data.client_cert = Some(client_cert.into());
         self
     }
 
@@ -217,6 +225,26 @@ pub(super) extern "C" fn get_client_username_by_id(
     ValkeyString::test(client_username.clone()).take()
 }
 
+pub(super) extern "C" fn get_client_certificate(
+    ctx: *mut raw::RedisModuleCtx,
+    client_id: libc::c_ulonglong,
+) -> *mut raw::RedisModuleString {
+    if ctx.is_null() {
+        return null_mut();
+    }
+
+    // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
+    let data = unsafe { &*ctx.cast::<ContextData>() };
+    if data.client_id != client_id {
+        return null_mut();
+    }
+    let Some(client_cert) = data.client_cert.as_ref() else {
+        return null_mut();
+    };
+
+    ValkeyString::test(client_cert.clone()).take()
+}
+
 pub(super) extern "C" fn get_client_info_by_id(
     output: *mut libc::c_void,
     client_id: libc::c_ulonglong,
@@ -312,6 +340,12 @@ pub(super) extern "C" fn authenticate_client_with_acl_user(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const TEST_CLIENT_CERTIFICATE: &str = concat!(
+        "-----BEGIN CERTIFICATE-----\n",
+        "VGhpcyBpcyBhIHRlc3QgY2xpZW50IGNlcnRpZmljYXRlLg==\n",
+        "-----END CERTIFICATE-----\n"
+    );
 
     #[test]
     fn returns_configured_client_id() {
@@ -632,6 +666,20 @@ mod tests {
                 .get_client_ip()
                 .expect("configured client IP should be returned"),
             "127.0.0.1"
+        );
+    }
+
+    #[test]
+    fn returns_configured_client_certificate() {
+        let mut context = Context::test();
+        context.expect_get_client_cert(TEST_CLIENT_CERTIFICATE);
+
+        assert_eq!(
+            context
+                .get_client_cert()
+                .expect("configured client certificate should be returned")
+                .as_slice(),
+            TEST_CLIENT_CERTIFICATE.as_bytes()
         );
     }
 }

--- a/src/test-shims/context.rs
+++ b/src/test-shims/context.rs
@@ -9,6 +9,8 @@ const DEFAULT_CLIENT_ID: u64 = 1;
 
 static SERVER_VERSION: AtomicI32 = AtomicI32::new(0);
 
+// These Valkey APIs do not receive a RedisModuleCtx, so their shims cannot access ContextData.
+// Thread-local state prevents expectations from leaking between concurrently running tests.
 thread_local! {
     static CLIENT_INFO_BY_ID: RefCell<HashMap<u64, RedisModuleClientInfo>> = RefCell::default();
     static CLIENT_NAME_BY_ID: RefCell<HashMap<u64, Vec<u8>>> = RefCell::default();
@@ -59,6 +61,7 @@ impl TestContext {
         // GetClientInfoById has no context parameter, so its shim uses per-thread state.
         // Reset that state before each test context to prevent stale expectations leaking.
         CLIENT_INFO_BY_ID.with(|client_info_by_id| client_info_by_id.borrow_mut().clear());
+        // CLIENT_NAME_BY_ID outlives TestContext, so clear names configured by earlier tests.
         CLIENT_NAME_BY_ID.with(|client_name_by_id| client_name_by_id.borrow_mut().clear());
 
         let ctx = (data.as_mut() as *mut ContextData).cast::<raw::RedisModuleCtx>();
@@ -664,8 +667,8 @@ mod tests {
         });
 
         let client_info = context
-            .get_client_info()
-            .expect("configured client info should be returned");
+            .get_client_info_by_id(42)
+            .expect("configured client info should be returned by ID");
 
         assert_eq!(client_info.version, 7);
         assert_eq!(client_info.id, 42);
@@ -738,6 +741,67 @@ mod tests {
         assert_eq!(
             context.set_client_name_by_id(7, &client_name),
             raw::Status::Err
+        );
+    }
+
+    #[test]
+    fn new_test_context_clears_thread_local_client_expectations() {
+        let mut first_context = Context::test();
+        first_context.expect_get_client_name_by_id(42, "alice");
+        first_context.expect_get_client_info_by_id(RedisModuleClientInfo {
+            id: 42,
+            ..RedisModuleClientInfo::default()
+        });
+
+        let second_context = Context::test();
+
+        assert!(matches!(
+            second_context.get_client_name_by_id(42),
+            Err(crate::ValkeyError::Str("Client/Client name is null"))
+        ));
+        assert!(matches!(
+            second_context.get_client_info_by_id(42),
+            Err(crate::ValkeyError::Str("Client/Info not found"))
+        ));
+    }
+
+    #[test]
+    fn returns_each_of_multiple_configured_client_info_entries() {
+        let mut context = Context::test();
+        context.expect_get_client_info_by_id(RedisModuleClientInfo {
+            id: 41,
+            port: 6379,
+            ..RedisModuleClientInfo::default()
+        });
+        context.expect_get_client_info_by_id(RedisModuleClientInfo {
+            id: 42,
+            port: 6380,
+            ..RedisModuleClientInfo::default()
+        });
+
+        let first = context
+            .get_client_info_by_id(41)
+            .expect("first configured client info should be returned");
+        let second = context
+            .get_client_info_by_id(42)
+            .expect("second configured client info should be returned");
+
+        assert_eq!((first.id, first.port), (41, 6379));
+        assert_eq!((second.id, second.port), (42, 6380));
+    }
+
+    #[test]
+    fn client_shims_reject_null_context_or_output() {
+        assert!(get_client_name_by_id(null_mut(), 42).is_null());
+        assert!(get_client_username_by_id(null_mut(), 42).is_null());
+        assert!(get_client_certificate(null_mut(), 42).is_null());
+        assert_eq!(
+            get_client_info_by_id(null_mut(), 42),
+            raw::Status::Err as libc::c_int
+        );
+        assert_eq!(
+            set_client_name_by_id(42, null_mut()),
+            raw::Status::Err as libc::c_int
         );
     }
 }

--- a/src/test-shims/context.rs
+++ b/src/test-shims/context.rs
@@ -1,4 +1,6 @@
-use crate::{raw, Context, ValkeyString};
+use crate::{raw, Context, RedisModuleClientInfo, ValkeyString};
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::ops::Deref;
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicI32, Ordering};
@@ -6,6 +8,10 @@ use std::sync::atomic::{AtomicI32, Ordering};
 const DEFAULT_CLIENT_ID: u64 = 1;
 
 static SERVER_VERSION: AtomicI32 = AtomicI32::new(0);
+
+thread_local! {
+    static CLIENT_INFO_BY_ID: RefCell<HashMap<u64, RedisModuleClientInfo>> = RefCell::default();
+}
 
 impl Context {
     /// Creates a test context whose API return values can be configured with `expect_*` methods.
@@ -48,6 +54,11 @@ impl TestContext {
         super::setup_test_shims();
 
         let mut data = Box::new(ContextData::default());
+
+        // GetClientInfoById has no context parameter, so its shim uses per-thread state.
+        // Reset that state before each test context to prevent stale expectations leaking.
+        CLIENT_INFO_BY_ID.with(|client_info_by_id| client_info_by_id.borrow_mut().clear());
+
         let ctx = (data.as_mut() as *mut ContextData).cast::<raw::RedisModuleCtx>();
 
         Self {
@@ -81,6 +92,21 @@ impl TestContext {
     ) -> &mut Self {
         self.data.client_id = client_id;
         self.data.client_username = Some(client_username.into());
+        self
+    }
+
+    /// Configures the client information returned for a client ID.
+    pub fn expect_get_client_info_by_id(
+        &mut self,
+        client_info: RedisModuleClientInfo,
+    ) -> &mut Self {
+        let client_id = client_info.id;
+        self.data.client_id = client_id;
+        CLIENT_INFO_BY_ID.with(|client_info_by_id| {
+            client_info_by_id
+                .borrow_mut()
+                .insert(client_id, client_info);
+        });
         self
     }
 
@@ -171,6 +197,27 @@ pub(super) extern "C" fn get_client_username_by_id(
     };
 
     ValkeyString::test(client_username.clone()).take()
+}
+
+pub(super) extern "C" fn get_client_info_by_id(
+    output: *mut libc::c_void,
+    client_id: libc::c_ulonglong,
+) -> libc::c_int {
+    if output.is_null() {
+        return raw::Status::Err as libc::c_int;
+    }
+
+    let client_info = CLIENT_INFO_BY_ID
+        .with(|client_info_by_id| client_info_by_id.borrow().get(&client_id).copied());
+    let Some(client_info) = client_info else {
+        return raw::Status::Err as libc::c_int;
+    };
+
+    // SAFETY: Valkey supplies a writable `RedisModuleClientInfo` output buffer.
+    unsafe {
+        output.cast::<RedisModuleClientInfo>().write(client_info);
+    }
+    raw::Status::Ok as libc::c_int
 }
 
 pub(super) extern "C" fn get_current_user_name(
@@ -513,5 +560,47 @@ mod tests {
         for options in module_options {
             context.set_module_options(options);
         }
+    }
+
+    #[test]
+    fn returns_configured_client_info() {
+        let mut context = Context::test();
+        context.expect_get_client_info_by_id(RedisModuleClientInfo {
+            version: 7,
+            id: 42,
+            port: 6379,
+            db: 2,
+            ..RedisModuleClientInfo::default()
+        });
+
+        let client_info = context
+            .get_client_info()
+            .expect("configured client info should be returned");
+
+        assert_eq!(client_info.version, 7);
+        assert_eq!(client_info.id, 42);
+        assert_eq!(client_info.port, 6379);
+        assert_eq!(client_info.db, 2);
+    }
+
+    #[test]
+    fn rejects_unconfigured_client_info() {
+        let context = Context::test();
+
+        assert!(matches!(
+            context.get_client_info(),
+            Err(crate::ValkeyError::Str("Client/Info not found"))
+        ));
+    }
+
+    #[test]
+    fn get_client_info_by_id_rejects_unknown_id() {
+        let _context = Context::test();
+        let mut client_info = RedisModuleClientInfo::default();
+
+        assert_eq!(
+            get_client_info_by_id((&mut client_info as *mut RedisModuleClientInfo).cast(), 42,),
+            raw::Status::Err as libc::c_int
+        );
     }
 }

--- a/src/test-shims/context.rs
+++ b/src/test-shims/context.rs
@@ -11,6 +11,7 @@ static SERVER_VERSION: AtomicI32 = AtomicI32::new(0);
 
 thread_local! {
     static CLIENT_INFO_BY_ID: RefCell<HashMap<u64, RedisModuleClientInfo>> = RefCell::default();
+    static CLIENT_NAME_BY_ID: RefCell<HashMap<u64, Vec<u8>>> = RefCell::default();
 }
 
 impl Context {
@@ -23,7 +24,6 @@ impl Context {
 
 struct ContextData {
     client_id: u64,
-    client_name: Option<Vec<u8>>,
     client_username: Option<Vec<u8>>,
     client_cert: Option<Vec<u8>>,
     current_user: Option<Vec<u8>>,
@@ -35,7 +35,6 @@ impl Default for ContextData {
     fn default() -> Self {
         Self {
             client_id: DEFAULT_CLIENT_ID,
-            client_name: None,
             client_username: None,
             client_cert: None,
             current_user: None,
@@ -60,6 +59,7 @@ impl TestContext {
         // GetClientInfoById has no context parameter, so its shim uses per-thread state.
         // Reset that state before each test context to prevent stale expectations leaking.
         CLIENT_INFO_BY_ID.with(|client_info_by_id| client_info_by_id.borrow_mut().clear());
+        CLIENT_NAME_BY_ID.with(|client_name_by_id| client_name_by_id.borrow_mut().clear());
 
         let ctx = (data.as_mut() as *mut ContextData).cast::<raw::RedisModuleCtx>();
 
@@ -82,7 +82,20 @@ impl TestContext {
         client_name: T,
     ) -> &mut Self {
         self.data.client_id = client_id;
-        self.data.client_name = Some(client_name.into());
+        CLIENT_NAME_BY_ID.with(|client_name_by_id| {
+            client_name_by_id
+                .borrow_mut()
+                .insert(client_id, client_name.into());
+        });
+        self
+    }
+
+    /// Configures a client ID accepted by [`Context::set_client_name_by_id`].
+    pub fn expect_set_client_name_by_id(&mut self, client_id: u64) -> &mut Self {
+        self.data.client_id = client_id;
+        CLIENT_NAME_BY_ID.with(|client_name_by_id| {
+            client_name_by_id.borrow_mut().entry(client_id).or_default();
+        });
         self
     }
 
@@ -194,15 +207,40 @@ pub(super) extern "C" fn get_client_name_by_id(
     }
 
     // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
-    let data = unsafe { &*ctx.cast::<ContextData>() };
-    if data.client_id != client_id {
-        return null_mut();
-    }
-    let Some(client_name) = data.client_name.as_ref() else {
+    let _data = unsafe { &*ctx.cast::<ContextData>() };
+    let client_name = CLIENT_NAME_BY_ID
+        .with(|client_name_by_id| client_name_by_id.borrow().get(&client_id).cloned());
+    let Some(client_name) = client_name else {
         return null_mut();
     };
 
-    ValkeyString::test(client_name.clone()).take()
+    ValkeyString::test(client_name).take()
+}
+
+pub(super) extern "C" fn set_client_name_by_id(
+    client_id: libc::c_ulonglong,
+    client_name: *mut raw::RedisModuleString,
+) -> libc::c_int {
+    if client_name.is_null() {
+        return raw::Status::Err as libc::c_int;
+    }
+
+    // SAFETY: Test strings passed to the shim are backed by `valkey_string::string_data`.
+    let client_name = unsafe { super::valkey_string::string_data(client_name) }.to_vec();
+    let updated = CLIENT_NAME_BY_ID.with(|client_name_by_id| {
+        let mut client_name_by_id = client_name_by_id.borrow_mut();
+        let Some(configured_name) = client_name_by_id.get_mut(&client_id) else {
+            return false;
+        };
+        *configured_name = client_name;
+        true
+    });
+
+    if updated {
+        raw::Status::Ok as libc::c_int
+    } else {
+        raw::Status::Err as libc::c_int
+    }
 }
 
 pub(super) extern "C" fn get_client_username_by_id(
@@ -680,6 +718,26 @@ mod tests {
                 .expect("configured client certificate should be returned")
                 .as_slice(),
             TEST_CLIENT_CERTIFICATE.as_bytes()
+        );
+    }
+
+    #[test]
+    fn updates_configured_client_name_and_rejects_unknown_client_id() {
+        let mut context = Context::test();
+        context.expect_set_client_name_by_id(42);
+        let client_name = context.create_string("bob");
+
+        assert_eq!(context.set_client_name(&client_name), raw::Status::Ok);
+        assert_eq!(
+            context
+                .get_client_name()
+                .expect("updated client name should be returned")
+                .as_slice(),
+            b"bob"
+        );
+        assert_eq!(
+            context.set_client_name_by_id(7, &client_name),
+            raw::Status::Err
         );
     }
 }

--- a/src/test-shims/context.rs
+++ b/src/test-shims/context.rs
@@ -110,6 +110,24 @@ impl TestContext {
         self
     }
 
+    /// Configures the client IP address returned for a client ID.
+    pub fn expect_get_client_ip_by_id(&mut self, client_id: u64, client_ip: &str) -> &mut Self {
+        assert!(
+            client_ip.len() < 46,
+            "client IP must fit in RedisModuleClientInfo::addr"
+        );
+
+        let mut client_info = RedisModuleClientInfo {
+            id: client_id,
+            ..RedisModuleClientInfo::default()
+        };
+        for (address_byte, ip_byte) in client_info.addr.iter_mut().zip(client_ip.bytes()) {
+            *address_byte = ip_byte as libc::c_char;
+        }
+
+        self.expect_get_client_info_by_id(client_info)
+    }
+
     /// Configures the username returned by [`Context::get_current_user`].
     pub fn expect_get_current_user<T: Into<Vec<u8>>>(&mut self, current_user: T) -> &mut Self {
         self.data.current_user = Some(current_user.into());
@@ -601,6 +619,19 @@ mod tests {
         assert_eq!(
             get_client_info_by_id((&mut client_info as *mut RedisModuleClientInfo).cast(), 42,),
             raw::Status::Err as libc::c_int
+        );
+    }
+
+    #[test]
+    fn returns_configured_client_ip() {
+        let mut context = Context::test();
+        context.expect_get_client_ip_by_id(42, "127.0.0.1");
+
+        assert_eq!(
+            context
+                .get_client_ip()
+                .expect("configured client IP should be returned"),
+            "127.0.0.1"
         );
     }
 }

--- a/src/test-shims/mod.rs
+++ b/src/test-shims/mod.rs
@@ -34,6 +34,7 @@ fn setup_test_shims() {
             raw::RedisModule_GetClientId = Some(context::get_client_id);
             raw::RedisModule_GetClientNameById = Some(context::get_client_name_by_id);
             raw::RedisModule_GetClientUserNameById = Some(context::get_client_username_by_id);
+            raw::RedisModule_GetClientInfoById = Some(context::get_client_info_by_id);
             raw::RedisModule_GetCurrentUserName = Some(context::get_current_user_name);
             raw::RedisModule_DeauthenticateAndCloseClient =
                 Some(context::deauthenticate_and_close_client);

--- a/src/test-shims/mod.rs
+++ b/src/test-shims/mod.rs
@@ -33,6 +33,7 @@ fn setup_test_shims() {
             // Context
             raw::RedisModule_GetClientId = Some(context::get_client_id);
             raw::RedisModule_GetClientNameById = Some(context::get_client_name_by_id);
+            raw::RedisModule_SetClientNameById = Some(context::set_client_name_by_id);
             raw::RedisModule_GetClientUserNameById = Some(context::get_client_username_by_id);
             raw::RedisModule_GetClientCertificate = Some(context::get_client_certificate);
             raw::RedisModule_GetClientInfoById = Some(context::get_client_info_by_id);

--- a/src/test-shims/mod.rs
+++ b/src/test-shims/mod.rs
@@ -34,6 +34,7 @@ fn setup_test_shims() {
             raw::RedisModule_GetClientId = Some(context::get_client_id);
             raw::RedisModule_GetClientNameById = Some(context::get_client_name_by_id);
             raw::RedisModule_GetClientUserNameById = Some(context::get_client_username_by_id);
+            raw::RedisModule_GetClientCertificate = Some(context::get_client_certificate);
             raw::RedisModule_GetClientInfoById = Some(context::get_client_info_by_id);
             raw::RedisModule_GetCurrentUserName = Some(context::get_current_user_name);
             raw::RedisModule_DeauthenticateAndCloseClient =

--- a/src/test-shims/valkey_string.rs
+++ b/src/test-shims/valkey_string.rs
@@ -174,7 +174,7 @@ fn parse_string<T: FromStr>(string: *const raw::RedisModuleString, value: *mut T
 ///
 /// `string` must be non-null, aligned, and point to a live `ShimString` previously passed through
 /// `Arc::into_raw`. The returned slice must not outlive that allocation.
-unsafe fn string_data<'a>(string: *const raw::RedisModuleString) -> &'a [u8] {
+pub(super) unsafe fn string_data<'a>(string: *const raw::RedisModuleString) -> &'a [u8] {
     // SAFETY: The caller guarantees the pointer provenance, alignment, and lifetime above.
     unsafe { (&*string.cast::<ShimString>()).as_slice() }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1257,10 +1257,10 @@ fn test_client() -> Result<()> {
         .with_context(|| "failed execute client.username")?;
     assert_eq!(resp, "default");
     // test client.cert
-    let resp: String = redis::cmd("client.cert")
-        .query(&mut con)
-        .with_context(|| "failed execute client.cert")?;
-    assert_eq!(resp, "");
+    let error = redis::cmd("client.cert")
+        .query::<String>(&mut con)
+        .expect_err("client.cert should fail when the client has no TLS certificate");
+    assert!(error.to_string().contains("Client/Cert: is null"));
     // test client.info
     let resp: String = redis::cmd("client.info")
         .query(&mut con)


### PR DESCRIPTION
  - Added test shims and Context::test() expectations for client info, IP, TLS certificates, and
    SetClientNameById.
  - Added RedisModuleClientInfo::default() and corrected get_client_info_by_id to honor Valkey’s
    returned status.
  - Added client wrapper and example-module unit tests, including missing/error paths.
  - Updated the client integration test: client.cert now correctly expects an error without a TLS
    client certificate.
  - Added ValkeyString and NextArg unit coverage for parsing, binary strings, UTF-8 handling,
    ownership, arity, and numeric errors.