### PR TITLE
adding shims for Context::call

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,11 @@ mod tests {
 }
 ```
 
-The test context currently supports configuring the server version, client IDs, client names, client usernames, the current user, ACL-user authentication, and client deauthentication. Configure `Context::get_server_version()` with `expect_get_server_version(major, minor, patch)`. Calls to `set_module_options` are accepted as a no-op because their effects require a running server. `Context::create_string()` also works with a test context:
+The test context supports configuring the server version, client IDs, names, usernames, certificates, client information and IP addresses, the current user, ACL-user authentication, and client deauthentication. Configure `Context::get_server_version()` with `expect_get_server_version(major, minor, patch)`.
+
+For client-specific expectations, use `expect_get_client_name_by_id`, `expect_get_client_username_by_id`, `expect_get_client_ip_by_id`, or `expect_set_client_name_by_id`. Configure detailed client information with `expect_get_client_info_by_id(RedisModuleClientInfo { id, ..Default::default() })`; the ID is read from the supplied structure. `expect_get_client_cert` configures the certificate returned for the current client. Each `Context::test()` resets these expectations, so tests do not inherit client state from earlier tests on the same thread.
+
+Calls to `set_module_options` are accepted as a no-op because their effects require a running server. `Context::create_string()` also works with a test context:
 
 ```rust
 let context = Context::test();

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ context.expect_call(
 );
 ```
 
+For [`Context::config_get()`], use `expect_config_get("hz", "10")` instead of configuring the underlying `CONFIG GET` reply directly.
+
 Calls to `set_module_options` are accepted as a no-op because their effects require a running server. `Context::create_string()` also works with a test context:
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -90,6 +90,21 @@ The test context supports configuring the server version, client IDs, names, use
 
 For client-specific expectations, use `expect_get_client_name_by_id`, `expect_get_client_username_by_id`, `expect_get_client_ip_by_id`, or `expect_set_client_name_by_id`. Configure detailed client information with `expect_get_client_info_by_id(RedisModuleClientInfo { id, ..Default::default() })`; the ID is read from the supplied structure. `expect_get_client_cert` configures the certificate returned for the current client. Each `Context::test()` resets these expectations, so tests do not inherit client state from earlier tests on the same thread.
 
+Use `expect_call` to configure an exact `Context::call()` command and argument list. It supports simple strings, integers, booleans, doubles, big numbers, nulls, maps, and nested arrays. An unconfigured call returns an error describing the unexpected command instead of invoking Valkey:
+
+```rust
+use valkey_module::ValkeyValue;
+
+context.expect_call(
+    "CONFIG",
+    &["GET", "hz"],
+    ValkeyValue::Array(vec![
+        ValkeyValue::SimpleString("hz".into()),
+        ValkeyValue::SimpleString("10".into()),
+    ]),
+);
+```
+
 Calls to `set_module_options` are accepted as a no-op because their effects require a running server. `Context::create_string()` also works with a test context:
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -144,6 +144,28 @@ assert_eq!(context.arg_get_try_as_str(1), Ok("new-key"));
 assert_eq!(context.get_client_id(), 42);
 ```
 
+To test a raw command-filter callback directly, pass `context.as_raw_ctx_ptr()` to it. The returned opaque pointer remains valid while the `TestCommandFilterCtx` is alive:
+
+```rust
+use valkey_module::{CommandFilterCtx, RedisModuleCommandFilterCtx};
+
+fn rewrite_set_filter(ctx: *mut RedisModuleCommandFilterCtx) {
+    let context = CommandFilterCtx::new(ctx);
+    context.arg_replace(1, "new-key");
+}
+
+let mut context = CommandFilterCtx::test();
+context
+    .expect_args_count(3)
+    .expect_arg_get(0, "SET")
+    .expect_arg_get(1, "key")
+    .expect_arg_get(2, "value");
+
+rewrite_set_filter(context.as_raw_ctx_ptr());
+
+assert_eq!(context.arg_get_try_as_str(1), Ok("new-key"));
+```
+
 `expect_args_count()` configures the reported number of arguments, while `expect_arg_get()` configures the binary-safe value at an individual position. The test context also supports command lookup, client ID lookup, and argument replacement, insertion, and deletion. Insertions and deletions update the argument count and shift subsequent arguments.
 
 Run these tests normally:

--- a/examples/call.rs
+++ b/examples/call.rs
@@ -178,6 +178,8 @@ valkey_module! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+    use valkey_module::redisvalue::ValkeyValueKey;
 
     #[test]
     fn context_creates_string() {
@@ -197,5 +199,49 @@ mod tests {
         let string = context.create_string("");
 
         assert!(string.is_empty());
+    }
+
+    #[test]
+    fn context_call_returns_configured_reply() {
+        let mut context = Context::test();
+        context.expect_call(
+            "ECHO",
+            &["unit-test"],
+            ValkeyValue::SimpleString("unit-test".to_owned()),
+        );
+
+        let reply: String = context
+            .call("ECHO", &["unit-test"])
+            .expect("configured call should return a reply")
+            .try_into()
+            .expect("configured string reply should convert to String");
+
+        assert_eq!(reply, "unit-test");
+    }
+
+    #[test]
+    fn call_test_accepts_configured_resp3_map_reply() {
+        let mut context = Context::test();
+        context.expect_call(
+            "ECHO",
+            &["TEST"],
+            ValkeyValue::SimpleString("TEST".to_owned()),
+        );
+        context.expect_call(
+            "SHUTDOWN",
+            &[] as &[&str],
+            ValkeyValue::StaticError("not allowed in script mode"),
+        );
+        context.expect_call("HSET", &["x", "foo", "bar"], ValkeyValue::Integer(1));
+        context.expect_call(
+            "HGETALL",
+            &["x"],
+            ValkeyValue::Map(HashMap::from([(
+                ValkeyValueKey::String("foo".to_owned()),
+                ValkeyValue::SimpleString("bar".to_owned()),
+            )])),
+        );
+
+        assert!(call_test(&context, Vec::new()).is_ok());
     }
 }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -245,4 +245,19 @@ mod tests {
             b"bob"
         );
     }
+
+    #[test]
+    fn returns_configured_config_value() {
+        let mut context = Context::test();
+        context.expect_config_get("maxmemory-policy", "noeviction");
+        let args = vec![
+            context.create_string("client.config_get"),
+            context.create_string("maxmemory-policy"),
+        ];
+
+        let result =
+            config_get(&context, args).expect("configured config value should be returned");
+
+        assert_eq!(result, ValkeyValue::BulkString("noeviction".into()));
+    }
 }

--- a/examples/filter1.rs
+++ b/examples/filter1.rs
@@ -110,3 +110,80 @@ valkey_module! {
         [filter2_fn, VALKEYMODULE_CMDFILTER_NOSELF]
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn info_filter_rewrites_info_command() {
+        let mut context = CommandFilterCtx::test();
+        context
+            .expect_args_count(1)
+            .expect_arg_get(0, "INFO")
+            .expect_get_client_id(42);
+
+        info_filter_fn(context.as_raw_ctx_ptr());
+
+        assert_eq!(context.cmd_get_try_as_str(), Ok("info2"));
+    }
+
+    #[test]
+    fn info_filter_leaves_unrelated_command_unchanged() {
+        let mut context = CommandFilterCtx::test();
+        context.expect_args_count(1).expect_arg_get(0, "PING");
+
+        info_filter_fn(context.as_raw_ctx_ptr());
+
+        assert_eq!(context.cmd_get_try_as_str(), Ok("PING"));
+    }
+
+    #[test]
+    fn set_filter_rewrites_key_and_value() {
+        let mut context = CommandFilterCtx::test();
+        context
+            .expect_args_count(3)
+            .expect_arg_get(0, "SET")
+            .expect_arg_get(1, "old_key")
+            .expect_arg_get(2, "old_value");
+
+        set_filter_fn(context.as_raw_ctx_ptr());
+
+        assert_eq!(context.args_count(), 3);
+        assert_eq!(context.cmd_get_try_as_str(), Ok("SET"));
+        assert_eq!(context.arg_get_try_as_str(1), Ok("new_key"));
+        assert_eq!(context.arg_get_try_as_str(2), Ok("new_value"));
+    }
+
+    #[test]
+    fn set_filter_leaves_wrong_arity_unchanged() {
+        let mut context = CommandFilterCtx::test();
+        context
+            .expect_args_count(2)
+            .expect_arg_get(0, "SET")
+            .expect_arg_get(1, "key");
+
+        set_filter_fn(context.as_raw_ctx_ptr());
+
+        assert_eq!(context.args_count(), 2);
+        assert_eq!(context.cmd_get_try_as_str(), Ok("SET"));
+        assert_eq!(context.arg_get_try_as_str(1), Ok("key"));
+    }
+
+    #[test]
+    fn set_filter_leaves_unrelated_command_unchanged() {
+        let mut context = CommandFilterCtx::test();
+        context
+            .expect_args_count(3)
+            .expect_arg_get(0, "GET")
+            .expect_arg_get(1, "key")
+            .expect_arg_get(2, "value");
+
+        set_filter_fn(context.as_raw_ctx_ptr());
+
+        assert_eq!(context.args_count(), 3);
+        assert_eq!(context.cmd_get_try_as_str(), Ok("GET"));
+        assert_eq!(context.arg_get_try_as_str(1), Ok("key"));
+        assert_eq!(context.arg_get_try_as_str(2), Ok("value"));
+    }
+}

--- a/examples/filter2.rs
+++ b/examples/filter2.rs
@@ -125,6 +125,18 @@ mod tests {
     }
 
     #[test]
+    fn invokes_command_filter_callback_with_test_context_pointer() {
+        let client_id = 43;
+        CLIENT_ID_USERNAME_MAP.insert(client_id, "alice".to_string());
+        let mut context = CommandFilterCtx::test();
+        context.expect_get_client_id(client_id);
+
+        filter1_fn(context.as_raw_ctx_ptr());
+
+        CLIENT_ID_USERNAME_MAP.remove(&client_id);
+    }
+
+    #[test]
     fn defaults_username_for_unknown_command_filter_client() {
         let mut context = CommandFilterCtx::test();
         context.expect_get_client_id(99);

--- a/src/context/client.rs
+++ b/src/context/client.rs
@@ -299,34 +299,79 @@ mod tests {
         assert_eq!(context.set_client_name_by_id(7, &client_name), Status::Err);
     }
 
-    #[test]
-    fn gets_configured_config_value() {
-        let mut context = Context::test();
-        context.expect_call(
-            "CONFIG",
-            &["GET", "hz"],
-            ValkeyValue::Array(vec![
-                ValkeyValue::SimpleString("hz".to_owned()),
-                ValkeyValue::SimpleString("10".to_owned()),
-            ]),
-        );
+    mod config_get {
+        use super::*;
 
-        assert_eq!(
-            context
-                .config_get("hz".to_owned())
-                .expect("configured config value should be returned")
-                .as_slice(),
-            b"10"
-        );
-    }
+        #[test]
+        fn gets_configured_value() {
+            let mut context = Context::test();
+            context.expect_config_get("hz", "10");
 
-    #[test]
-    fn rejects_unconfigured_test_call() {
-        let context = Context::test();
+            assert_eq!(
+                context
+                    .config_get("hz".to_owned())
+                    .expect("configured config value should be returned")
+                    .as_slice(),
+                b"10"
+            );
+        }
 
-        assert!(matches!(
-            context.config_get("hz".to_owned()),
-            Err(ValkeyError::String(message)) if message == "unexpected call: CONFIG GET hz"
-        ));
+        #[test]
+        fn rejects_reply_with_unexpected_shape() {
+            let mut context = Context::test();
+            context.expect_call(
+                "CONFIG",
+                &["GET", "hz"],
+                ValkeyValue::Array(vec![ValkeyValue::SimpleString("hz".to_owned())]),
+            );
+
+            assert!(matches!(
+                context.config_get("hz".to_owned()),
+                Err(ValkeyError::Str("Unexpected CONFIG GET response"))
+            ));
+        }
+
+        #[test]
+        fn rejects_reply_with_non_string_value() {
+            let mut context = Context::test();
+            context.expect_call(
+                "CONFIG",
+                &["GET", "hz"],
+                ValkeyValue::Array(vec![
+                    ValkeyValue::SimpleString("hz".to_owned()),
+                    ValkeyValue::Integer(10),
+                ]),
+            );
+
+            assert!(matches!(
+                context.config_get("hz".to_owned()),
+                Err(ValkeyError::Str("Config value is not a string"))
+            ));
+        }
+
+        #[test]
+        fn propagates_call_error() {
+            let mut context = Context::test();
+            context.expect_call(
+                "CONFIG",
+                &["GET", "hz"],
+                ValkeyValue::StaticError("ERR permission denied"),
+            );
+
+            assert!(matches!(
+                context.config_get("hz".to_owned()),
+                Err(ValkeyError::String(message)) if message == "ERR permission denied"
+            ));
+        }
+
+        #[test]
+        fn rejects_unconfigured_test_call() {
+            let context = Context::test();
+
+            assert!(matches!(
+                context.config_get("hz".to_owned()),
+                Err(ValkeyError::String(message)) if message == "unexpected call: CONFIG GET hz"
+            ));
+        }
     }
 }

--- a/src/context/client.rs
+++ b/src/context/client.rs
@@ -298,4 +298,35 @@ mod tests {
         assert_eq!(context.set_client_name(&client_name), Status::Ok);
         assert_eq!(context.set_client_name_by_id(7, &client_name), Status::Err);
     }
+
+    #[test]
+    fn gets_configured_config_value() {
+        let mut context = Context::test();
+        context.expect_call(
+            "CONFIG",
+            &["GET", "hz"],
+            ValkeyValue::Array(vec![
+                ValkeyValue::SimpleString("hz".to_owned()),
+                ValkeyValue::SimpleString("10".to_owned()),
+            ]),
+        );
+
+        assert_eq!(
+            context
+                .config_get("hz".to_owned())
+                .expect("configured config value should be returned")
+                .as_slice(),
+            b"10"
+        );
+    }
+
+    #[test]
+    fn rejects_unconfigured_test_call() {
+        let context = Context::test();
+
+        assert!(matches!(
+            context.config_get("hz".to_owned()),
+            Err(ValkeyError::String(message)) if message == "unexpected call: CONFIG GET hz"
+        ));
+    }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -414,6 +414,14 @@ impl Context {
         let mut call_args: StrCallArgs = args.into();
         let final_args = call_args.args_mut();
 
+        #[cfg(any(test, feature = "test-shims"))]
+        // Test contexts return configured replies here because stable Rust cannot implement the
+        // C-variadic RedisModule_Call API for the test shim.
+        if let Some(reply) = crate::test_shims::try_call(self.ctx, command, final_args) {
+            let promise = create_promise_call_reply(self, NonNull::new(reply));
+            return R::from(promise);
+        }
+
         let cmd = CString::new(command).unwrap();
         let reply: *mut raw::RedisModuleCallReply = unsafe {
             let p_call = raw::RedisModule_Call.unwrap();

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -11,6 +11,8 @@ use crate::key::{KeyFlags, ValkeyKey, ValkeyKeyWritable};
 use crate::logging::ValkeyLogLevel;
 use crate::raw::{ModuleOptions, Version};
 use crate::redisvalue::ValkeyValueKey;
+#[cfg(any(test, feature = "test-shims"))]
+use crate::test_shims::try_call;
 use crate::{
     add_info_begin_dict_field, add_info_end_dict_field, add_info_field_double,
     add_info_field_long_long, add_info_field_str, add_info_field_unsigned_long_long, raw, utils,
@@ -417,7 +419,7 @@ impl Context {
         #[cfg(any(test, feature = "test-shims"))]
         // Test contexts return configured replies here because stable Rust cannot implement the
         // C-variadic RedisModule_Call API for the test shim.
-        if let Some(reply) = crate::test_shims::try_call(self.ctx, command, final_args) {
+        if let Some(reply) = try_call(self.ctx, command, final_args) {
             let promise = create_promise_call_reply(self, NonNull::new(reply));
             return R::from(promise);
         }

--- a/src/test-shims/call.rs
+++ b/src/test-shims/call.rs
@@ -1,0 +1,404 @@
+use crate::redisvalue::ValkeyValueKey;
+use crate::{raw, ValkeyValue};
+use std::sync::Arc;
+
+/// Owns a test-shim call reply while allowing array elements to share its value.
+#[derive(Clone)]
+pub(super) struct TestCallReply {
+    value: Arc<TestCallReplyValue>,
+}
+
+/// Stores the reply variants exposed through Valkey's call-reply API.
+enum TestCallReplyValue {
+    String(Vec<u8>),
+    Error(Vec<u8>),
+    Integer(i64),
+    Bool(bool),
+    Double(f64),
+    BigNumber(Vec<u8>),
+    Array(Vec<Arc<TestCallReplyValue>>),
+    Map(Vec<(Arc<TestCallReplyValue>, Arc<TestCallReplyValue>)>),
+    Null,
+}
+
+// Constructs and transfers owned mock call-reply handles.
+impl TestCallReply {
+    /// Converts a supported high-level value into a mock call reply.
+    pub(super) fn from_value(value: ValkeyValue) -> Result<Self, &'static str> {
+        Ok(Self {
+            value: TestCallReplyValue::from_value(value)?,
+        })
+    }
+
+    /// Creates an error reply for an unexpected call.
+    pub(super) fn error(message: impl Into<Vec<u8>>) -> Self {
+        Self {
+            value: Arc::new(TestCallReplyValue::Error(message.into())),
+        }
+    }
+
+    /// Transfers this reply to the raw API; `free_call_reply` reclaims it.
+    pub(super) fn into_raw(self) -> *mut raw::RedisModuleCallReply {
+        Box::into_raw(Box::new(self)).cast()
+    }
+}
+
+// Converts high-level test values into the reply variants supported by the shim.
+impl TestCallReplyValue {
+    /// Recursively converts values that the call-reply shim can expose.
+    fn from_value(value: ValkeyValue) -> Result<Arc<Self>, &'static str> {
+        let value = match value {
+            ValkeyValue::SimpleString(value) => Self::String(value.into_bytes()),
+            ValkeyValue::SimpleStringStatic(value) => Self::String(value.as_bytes().to_vec()),
+            ValkeyValue::BulkString(value) => Self::String(value.into_bytes()),
+            ValkeyValue::StringBuffer(value) => Self::String(value),
+            ValkeyValue::Integer(value) => Self::Integer(value),
+            ValkeyValue::Bool(value) => Self::Bool(value),
+            ValkeyValue::Float(value) => Self::Double(value),
+            ValkeyValue::BigNumber(value) => Self::BigNumber(value.into_bytes()),
+            ValkeyValue::Array(values) => Self::Array(
+                values
+                    .into_iter()
+                    .map(Self::from_value)
+                    .collect::<Result<_, _>>()?,
+            ),
+            ValkeyValue::Map(values) => Self::Map(Self::map_entries(values)?),
+            ValkeyValue::OrderedMap(values) => Self::Map(Self::map_entries(values)?),
+            ValkeyValue::Null => Self::Null,
+            ValkeyValue::StaticError(value) => Self::Error(value.as_bytes().to_vec()),
+            _ => return Err("test-shim calls do not support this reply type"),
+        };
+        Ok(Arc::new(value))
+    }
+
+    /// Converts each map key and recursively converts its associated value.
+    fn map_entries(
+        values: impl IntoIterator<Item = (ValkeyValueKey, ValkeyValue)>,
+    ) -> Result<Vec<(Arc<Self>, Arc<Self>)>, &'static str> {
+        values
+            .into_iter()
+            .map(|(key, value)| Ok((Self::from_key(key), Self::from_value(value)?)))
+            .collect()
+    }
+
+    /// Converts a `ValkeyValueKey` into a reply value that can be returned by map iteration.
+    fn from_key(value: ValkeyValueKey) -> Arc<Self> {
+        Arc::new(match value {
+            ValkeyValueKey::Integer(value) => Self::Integer(value),
+            ValkeyValueKey::String(value) => Self::String(value.into_bytes()),
+            ValkeyValueKey::BulkValkeyString(value) => Self::String(value.as_slice().to_vec()),
+            ValkeyValueKey::BulkString(value) => Self::String(value),
+            ValkeyValueKey::Bool(value) => Self::Bool(value),
+        })
+    }
+}
+
+/// Implements `RedisModule_CallReplyType` for test replies.
+pub(super) extern "C" fn call_reply_type(reply: *mut raw::RedisModuleCallReply) -> libc::c_int {
+    with_reply_value(reply, |value| match value {
+        TestCallReplyValue::String(_) => raw::ReplyType::String as libc::c_int,
+        TestCallReplyValue::Error(_) => raw::ReplyType::Error as libc::c_int,
+        TestCallReplyValue::Integer(_) => raw::ReplyType::Integer as libc::c_int,
+        TestCallReplyValue::Bool(_) => raw::ReplyType::Bool as libc::c_int,
+        TestCallReplyValue::Double(_) => raw::ReplyType::Double as libc::c_int,
+        TestCallReplyValue::BigNumber(_) => raw::ReplyType::BigNumber as libc::c_int,
+        TestCallReplyValue::Array(_) => raw::ReplyType::Array as libc::c_int,
+        TestCallReplyValue::Map(_) => raw::ReplyType::Map as libc::c_int,
+        TestCallReplyValue::Null => raw::ReplyType::Null as libc::c_int,
+    })
+    .unwrap_or(raw::ReplyType::Null as libc::c_int)
+}
+
+/// Implements `RedisModule_FreeCallReply` for test replies.
+pub(super) extern "C" fn free_call_reply(reply: *mut raw::RedisModuleCallReply) {
+    if !reply.is_null() {
+        // SAFETY: each reply pointer is allocated as a `TestCallReply` handle.
+        unsafe { drop(Box::from_raw(reply.cast::<TestCallReply>())) };
+    }
+}
+
+/// Implements `RedisModule_CallReplyInteger` for test replies.
+pub(super) extern "C" fn call_reply_integer(
+    reply: *mut raw::RedisModuleCallReply,
+) -> libc::c_longlong {
+    with_reply_value(reply, |value| match value {
+        TestCallReplyValue::Integer(value) => *value,
+        _ => 0,
+    })
+    .unwrap_or(0)
+}
+
+/// Implements `RedisModule_CallReplyBool` for test replies.
+pub(super) extern "C" fn call_reply_bool(reply: *mut raw::RedisModuleCallReply) -> libc::c_int {
+    with_reply_value(reply, |value| {
+        matches!(value, TestCallReplyValue::Bool(true))
+    })
+    .unwrap_or(false) as libc::c_int
+}
+
+/// Implements `RedisModule_CallReplyDouble` for test replies.
+pub(super) extern "C" fn call_reply_double(reply: *mut raw::RedisModuleCallReply) -> f64 {
+    with_reply_value(reply, |value| match value {
+        TestCallReplyValue::Double(value) => *value,
+        _ => 0.0,
+    })
+    .unwrap_or(0.0)
+}
+
+/// Implements `RedisModule_CallReplyBigNumber` for test replies.
+pub(super) extern "C" fn call_reply_big_number(
+    reply: *mut raw::RedisModuleCallReply,
+    len: *mut usize,
+) -> *const libc::c_char {
+    with_reply_value(reply, |value| {
+        let TestCallReplyValue::BigNumber(value) = value else {
+            return std::ptr::null();
+        };
+        if !len.is_null() {
+            // SAFETY: Valkey supplies a writable length output pointer.
+            unsafe { len.write(value.len()) };
+        }
+        value.as_ptr().cast()
+    })
+    .unwrap_or(std::ptr::null())
+}
+
+/// Implements `RedisModule_CallReplyLength` for test replies.
+pub(super) extern "C" fn call_reply_length(reply: *mut raw::RedisModuleCallReply) -> usize {
+    with_reply_value(reply, |value| match value {
+        TestCallReplyValue::Array(values) => values.len(),
+        TestCallReplyValue::Map(values) => values.len(),
+        _ => 0,
+    })
+    .unwrap_or(0)
+}
+
+/// Implements `RedisModule_CallReplyArrayElement` for test replies.
+pub(super) extern "C" fn call_reply_array_element(
+    reply: *mut raw::RedisModuleCallReply,
+    index: usize,
+) -> *mut raw::RedisModuleCallReply {
+    with_reply_value(reply, |value| {
+        let TestCallReplyValue::Array(values) = value else {
+            return std::ptr::null_mut();
+        };
+        let Some(value) = values.get(index) else {
+            return std::ptr::null_mut();
+        };
+        TestCallReply {
+            value: Arc::clone(value),
+        }
+        .into_raw()
+    })
+    .unwrap_or(std::ptr::null_mut())
+}
+
+/// Implements `RedisModule_CallReplyMapElement` for test replies.
+pub(super) extern "C" fn call_reply_map_element(
+    reply: *mut raw::RedisModuleCallReply,
+    index: usize,
+    key: *mut *mut raw::RedisModuleCallReply,
+    value: *mut *mut raw::RedisModuleCallReply,
+) -> libc::c_int {
+    with_reply_value(reply, |reply| {
+        let TestCallReplyValue::Map(entries) = reply else {
+            return raw::Status::Err as libc::c_int;
+        };
+        let Some((map_key, map_value)) = entries.get(index) else {
+            return raw::Status::Err as libc::c_int;
+        };
+        if key.is_null() || value.is_null() {
+            return raw::Status::Err as libc::c_int;
+        }
+
+        // SAFETY: both output pointers are non-null and receive newly allocated reply handles.
+        unsafe {
+            key.write(
+                TestCallReply {
+                    value: Arc::clone(map_key),
+                }
+                .into_raw(),
+            );
+            value.write(
+                TestCallReply {
+                    value: Arc::clone(map_value),
+                }
+                .into_raw(),
+            );
+        }
+        raw::Status::Ok as libc::c_int
+    })
+    .unwrap_or(raw::Status::Err as libc::c_int)
+}
+
+/// Implements `RedisModule_CallReplyStringPtr` for test replies.
+pub(super) extern "C" fn call_reply_string_ptr(
+    reply: *mut raw::RedisModuleCallReply,
+    len: *mut usize,
+) -> *const libc::c_char {
+    with_reply_value(reply, |value| {
+        let value = match value {
+            TestCallReplyValue::String(value) | TestCallReplyValue::Error(value) => value,
+            _ => return std::ptr::null(),
+        };
+        if !len.is_null() {
+            // SAFETY: Valkey supplies a writable length output pointer.
+            unsafe { len.write(value.len()) };
+        }
+        value.as_ptr().cast()
+    })
+    .unwrap_or(std::ptr::null())
+}
+
+/// Calls `f` with the value held by a non-null test reply.
+fn with_reply_value<R>(
+    reply: *mut raw::RedisModuleCallReply,
+    f: impl FnOnce(&TestCallReplyValue) -> R,
+) -> Option<R> {
+    if reply.is_null() {
+        return None;
+    }
+
+    // SAFETY: all non-null replies originate from `TestCallReply::into_raw` or
+    // `call_reply_array_element`, which allocate a `TestCallReply` handle.
+    // SAFETY: the handle remains live for the duration of this callback.
+    Some(f(unsafe { &*reply.cast::<TestCallReply>() }.value.as_ref()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::redisvalue::ValkeyValueKey;
+    use std::collections::HashMap;
+
+    #[test]
+    fn exposes_scalar_reply_values() {
+        let string = raw_reply(ValkeyValue::StringBuffer(vec![0, 0xff]));
+        assert_eq!(
+            call_reply_type(string),
+            raw::ReplyType::String as libc::c_int
+        );
+        assert_eq!(
+            unsafe { reply_bytes(string, call_reply_string_ptr) },
+            [0, 0xff]
+        );
+        free_call_reply(string);
+
+        let error = TestCallReply::error(b"ERR failure".to_vec()).into_raw();
+        assert_eq!(call_reply_type(error), raw::ReplyType::Error as libc::c_int);
+        assert_eq!(
+            unsafe { reply_bytes(error, call_reply_string_ptr) },
+            b"ERR failure"
+        );
+        free_call_reply(error);
+
+        let integer = raw_reply(ValkeyValue::Integer(-42));
+        assert_eq!(
+            call_reply_type(integer),
+            raw::ReplyType::Integer as libc::c_int
+        );
+        assert_eq!(call_reply_integer(integer), -42);
+        free_call_reply(integer);
+
+        let boolean = raw_reply(ValkeyValue::Bool(true));
+        assert_eq!(
+            call_reply_type(boolean),
+            raw::ReplyType::Bool as libc::c_int
+        );
+        assert_eq!(call_reply_bool(boolean), 1);
+        free_call_reply(boolean);
+
+        let double = raw_reply(ValkeyValue::Float(1.5));
+        assert_eq!(
+            call_reply_type(double),
+            raw::ReplyType::Double as libc::c_int
+        );
+        assert_eq!(call_reply_double(double), 1.5);
+        free_call_reply(double);
+
+        let big_number = raw_reply(ValkeyValue::BigNumber("12345678901234567890".to_owned()));
+        assert_eq!(
+            call_reply_type(big_number),
+            raw::ReplyType::BigNumber as libc::c_int
+        );
+        assert_eq!(
+            unsafe { reply_bytes(big_number, call_reply_big_number) },
+            b"12345678901234567890"
+        );
+        free_call_reply(big_number);
+    }
+
+    #[test]
+    fn exposes_nested_array_replies_and_nulls() {
+        let reply = raw_reply(ValkeyValue::Array(vec![
+            ValkeyValue::Integer(7),
+            ValkeyValue::Array(vec![ValkeyValue::Null]),
+        ]));
+
+        assert_eq!(call_reply_type(reply), raw::ReplyType::Array as libc::c_int);
+        assert_eq!(call_reply_length(reply), 2);
+        assert!(call_reply_array_element(reply, 2).is_null());
+
+        let integer = call_reply_array_element(reply, 0);
+        assert_eq!(call_reply_integer(integer), 7);
+        free_call_reply(integer);
+
+        let nested = call_reply_array_element(reply, 1);
+        assert_eq!(call_reply_length(nested), 1);
+        let null = call_reply_array_element(nested, 0);
+        assert_eq!(call_reply_type(null), raw::ReplyType::Null as libc::c_int);
+        free_call_reply(null);
+        free_call_reply(nested);
+        free_call_reply(reply);
+    }
+
+    #[test]
+    fn exposes_map_reply_entries() {
+        let reply = raw_reply(ValkeyValue::Map(HashMap::from([(
+            ValkeyValueKey::String("key".to_owned()),
+            ValkeyValue::SimpleString("value".to_owned()),
+        )])));
+
+        assert_eq!(call_reply_type(reply), raw::ReplyType::Map as libc::c_int);
+        assert_eq!(call_reply_length(reply), 1);
+
+        let mut key = std::ptr::null_mut();
+        let mut value = std::ptr::null_mut();
+        assert_eq!(
+            call_reply_map_element(reply, 0, &mut key, &mut value),
+            raw::Status::Ok as libc::c_int
+        );
+        assert_eq!(unsafe { reply_bytes(key, call_reply_string_ptr) }, b"key");
+        assert_eq!(
+            unsafe { reply_bytes(value, call_reply_string_ptr) },
+            b"value"
+        );
+        free_call_reply(key);
+        free_call_reply(value);
+        free_call_reply(reply);
+    }
+
+    #[test]
+    fn rejects_unsupported_reply_type() {
+        assert!(matches!(
+            TestCallReply::from_value(ValkeyValue::Set(std::collections::HashSet::new())),
+            Err("test-shim calls do not support this reply type")
+        ));
+    }
+
+    fn raw_reply(value: ValkeyValue) -> *mut raw::RedisModuleCallReply {
+        TestCallReply::from_value(value)
+            .expect("reply value should be supported by the test shim")
+            .into_raw()
+    }
+
+    unsafe fn reply_bytes(
+        reply: *mut raw::RedisModuleCallReply,
+        get: extern "C" fn(*mut raw::RedisModuleCallReply, *mut usize) -> *const libc::c_char,
+    ) -> Vec<u8> {
+        let mut len = 0;
+        let value = get(reply, &mut len);
+        // SAFETY: `get` returns a pointer into the live test reply, and `len` is its byte length.
+        unsafe { std::slice::from_raw_parts(value.cast::<u8>(), len).to_vec() }
+    }
+}

--- a/src/test-shims/command_filter_ctx.rs
+++ b/src/test-shims/command_filter_ctx.rs
@@ -49,6 +49,13 @@ impl TestCommandFilterCtx {
         }
     }
 
+    /// Returns the opaque context pointer for invoking a command-filter callback in a test.
+    ///
+    /// The pointer remains valid while this test context is alive.
+    pub fn as_raw_ctx_ptr(&mut self) -> *mut raw::RedisModuleCommandFilterCtx {
+        (self.data.as_mut() as *mut CommandFilterData).cast()
+    }
+
     /// Configures the value returned by [`CommandFilterCtx::args_count`].
     pub fn expect_args_count(&mut self, args_count: libc::c_int) -> &mut Self {
         self.data.args_count = args_count;
@@ -451,6 +458,20 @@ mod tests {
         context.expect_get_client_id(10).expect_get_client_id(20);
 
         assert_eq!(context.get_client_id(), 20);
+    }
+
+    #[test]
+    fn exposes_raw_context_pointer_for_command_filter_callbacks() {
+        extern "C" fn replace_argument(ctx: *mut raw::RedisModuleCommandFilterCtx) {
+            CommandFilterCtx::new(ctx).arg_replace(1, "new");
+        }
+
+        let mut context = CommandFilterCtx::test();
+        context.expect_args_count(2).expect_arg_get(1, "old");
+
+        replace_argument(context.as_raw_ctx_ptr());
+
+        assert_eq!(context.arg_get_try_as_str(1), Ok("new"));
     }
 
     #[test]

--- a/src/test-shims/context.rs
+++ b/src/test-shims/context.rs
@@ -196,6 +196,23 @@ impl TestContext {
         self
     }
 
+    /// Configures the value returned by [`Context::config_get`] for a configuration name.
+    pub fn expect_config_get(
+        &mut self,
+        config: impl Into<String>,
+        value: impl Into<String>,
+    ) -> &mut Self {
+        let config = config.into();
+        self.expect_call(
+            "CONFIG",
+            &["GET", config.as_str()],
+            ValkeyValue::Array(vec![
+                ValkeyValue::SimpleString(config.clone()),
+                ValkeyValue::SimpleString(value.into()),
+            ]),
+        )
+    }
+
     /// Configures a reply returned by [`Context::call`] for an exact command and argument list.
     pub fn expect_call<T: AsRef<[u8]>>(
         &mut self,

--- a/src/test-shims/context.rs
+++ b/src/test-shims/context.rs
@@ -1,4 +1,5 @@
-use crate::{raw, Context, RedisModuleClientInfo, ValkeyString};
+use super::call::TestCallReply;
+use crate::{raw, Context, RedisModuleClientInfo, ValkeyString, ValkeyValue};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ops::Deref;
@@ -14,6 +15,7 @@ static SERVER_VERSION: AtomicI32 = AtomicI32::new(0);
 thread_local! {
     static CLIENT_INFO_BY_ID: RefCell<HashMap<u64, RedisModuleClientInfo>> = RefCell::default();
     static CLIENT_NAME_BY_ID: RefCell<HashMap<u64, Vec<u8>>> = RefCell::default();
+    static TEST_CONTEXTS: RefCell<std::collections::HashSet<usize>> = RefCell::default();
 }
 
 impl Context {
@@ -31,6 +33,14 @@ struct ContextData {
     current_user: Option<Vec<u8>>,
     acl_user: Option<Vec<u8>>,
     deauthentication_expected: bool,
+    call_expectations: Vec<CallExpectation>,
+}
+
+/// Matches one exact test-context command invocation to its configured reply.
+struct CallExpectation {
+    command: Vec<u8>,
+    args: Vec<Vec<u8>>,
+    reply: TestCallReply,
 }
 
 impl Default for ContextData {
@@ -42,6 +52,7 @@ impl Default for ContextData {
             current_user: None,
             acl_user: None,
             deauthentication_expected: false,
+            call_expectations: Vec::new(),
         }
     }
 }
@@ -57,14 +68,16 @@ impl TestContext {
         super::setup_test_shims();
 
         let mut data = Box::new(ContextData::default());
+        let ctx = (data.as_mut() as *mut ContextData).cast::<raw::RedisModuleCtx>();
 
         // GetClientInfoById has no context parameter, so its shim uses per-thread state.
         // Reset that state before each test context to prevent stale expectations leaking.
         CLIENT_INFO_BY_ID.with(|client_info_by_id| client_info_by_id.borrow_mut().clear());
         // CLIENT_NAME_BY_ID outlives TestContext, so clear names configured by earlier tests.
         CLIENT_NAME_BY_ID.with(|client_name_by_id| client_name_by_id.borrow_mut().clear());
-
-        let ctx = (data.as_mut() as *mut ContextData).cast::<raw::RedisModuleCtx>();
+        TEST_CONTEXTS.with(|test_contexts| {
+            test_contexts.borrow_mut().insert(ctx as usize);
+        });
 
         Self {
             context: Context::new(ctx),
@@ -182,6 +195,35 @@ impl TestContext {
         self.data.deauthentication_expected = true;
         self
     }
+
+    /// Configures a reply returned by [`Context::call`] for an exact command and argument list.
+    pub fn expect_call<T: AsRef<[u8]>>(
+        &mut self,
+        command: impl AsRef<[u8]>,
+        args: &[T],
+        reply: ValkeyValue,
+    ) -> &mut Self {
+        let reply = TestCallReply::from_value(reply)
+            .expect("unsupported reply type configured for test-shim call");
+        self.data.call_expectations.push(CallExpectation {
+            command: command.as_ref().to_vec(),
+            args: args.iter().map(|arg| arg.as_ref().to_vec()).collect(),
+            reply,
+        });
+        self
+    }
+}
+
+// Removes the context address when the backing test data is about to be released.
+impl Drop for TestContext {
+    fn drop(&mut self) {
+        // A recycled allocation must not be mistaken for a live test context.
+        TEST_CONTEXTS.with(|test_contexts| {
+            test_contexts
+                .borrow_mut()
+                .remove(&(self.context.ctx as usize));
+        });
+    }
 }
 
 impl Deref for TestContext {
@@ -190,6 +232,48 @@ impl Deref for TestContext {
     fn deref(&self) -> &Self::Target {
         &self.context
     }
+}
+
+/// Returns a configured reply when `ctx` belongs to a live `TestContext`.
+///
+/// `None` lets ordinary contexts invoke the real Valkey API.
+pub(crate) fn try_call(
+    ctx: *mut raw::RedisModuleCtx,
+    command: &str,
+    args: &[*mut raw::RedisModuleString],
+) -> Option<*mut raw::RedisModuleCallReply> {
+    let is_test_context =
+        TEST_CONTEXTS.with(|test_contexts| test_contexts.borrow().contains(&(ctx as usize)));
+    if !is_test_context {
+        return None;
+    }
+
+    // SAFETY: `ctx` is registered only while its owning `TestContext` is live.
+    let data = unsafe { &mut *ctx.cast::<ContextData>() };
+    let args = args
+        .iter()
+        .map(|arg| {
+            // SAFETY: call arguments for a test context are allocated by the string test shim.
+            unsafe { super::valkey_string::string_data(*arg) }.to_vec()
+        })
+        .collect::<Vec<_>>();
+    let reply = data
+        .call_expectations
+        .iter()
+        .find(|expectation| expectation.command == command.as_bytes() && expectation.args == args)
+        .map(|expectation| expectation.reply.clone());
+
+    let reply = match reply {
+        Some(reply) => reply,
+        None => TestCallReply::error(format!(
+            "unexpected call: {command} {}",
+            args.iter()
+                .map(|arg| String::from_utf8_lossy(arg))
+                .collect::<Vec<_>>()
+                .join(" ")
+        )),
+    };
+    Some(reply.into_raw())
 }
 
 pub(super) extern "C" fn get_client_id(ctx: *mut raw::RedisModuleCtx) -> libc::c_ulonglong {
@@ -803,5 +887,144 @@ mod tests {
             set_client_name_by_id(42, null_mut()),
             raw::Status::Err as libc::c_int
         );
+    }
+
+    #[test]
+    fn returns_configured_call_reply() {
+        let mut context = Context::test();
+        let expected = ValkeyValue::Array(vec![
+            ValkeyValue::SimpleString("value".to_owned()),
+            ValkeyValue::Integer(42),
+            ValkeyValue::Bool(true),
+            ValkeyValue::Float(1.5),
+            ValkeyValue::BigNumber("12345678901234567890".to_owned()),
+            ValkeyValue::Null,
+            ValkeyValue::Array(vec![ValkeyValue::SimpleString("nested".to_owned())]),
+        ]);
+        context.expect_call("TEST", &["argument"], expected.clone());
+
+        assert_eq!(
+            context
+                .call("TEST", &["argument"])
+                .expect("configured call reply should be returned"),
+            expected
+        );
+    }
+
+    #[test]
+    fn returns_configured_ordered_map_call_reply() {
+        let mut context = Context::test();
+        context.expect_call(
+            "HGETALL",
+            &["hash"],
+            ValkeyValue::OrderedMap(std::collections::BTreeMap::from([(
+                crate::redisvalue::ValkeyValueKey::String("field".to_owned()),
+                ValkeyValue::SimpleString("value".to_owned()),
+            )])),
+        );
+
+        assert_eq!(
+            context
+                .call("HGETALL", &["hash"])
+                .expect("configured ordered map reply should be returned"),
+            ValkeyValue::Map(std::collections::HashMap::from([(
+                crate::redisvalue::ValkeyValueKey::String("field".to_owned()),
+                ValkeyValue::SimpleString("value".to_owned()),
+            )]))
+        );
+    }
+
+    #[test]
+    fn matches_configured_binary_call_arguments() {
+        let mut context = Context::test();
+        context.expect_call(
+            "ECHO",
+            &[b"\0\xff".as_slice()],
+            ValkeyValue::SimpleString("matched".to_owned()),
+        );
+
+        assert_eq!(
+            context
+                .call("ECHO", &[b"\0\xff".as_slice()])
+                .expect("configured binary argument should match"),
+            ValkeyValue::SimpleString("matched".to_owned())
+        );
+    }
+
+    #[test]
+    fn returns_each_of_multiple_configured_call_replies() {
+        let mut context = Context::test();
+        context.expect_call("GET", &["first"], ValkeyValue::Integer(1));
+        context.expect_call("GET", &["second"], ValkeyValue::Integer(2));
+
+        assert_eq!(
+            context
+                .call("GET", &["first"])
+                .expect("first configured call should return a reply"),
+            ValkeyValue::Integer(1)
+        );
+        assert_eq!(
+            context
+                .call("GET", &["second"])
+                .expect("second configured call should return a reply"),
+            ValkeyValue::Integer(2)
+        );
+    }
+
+    #[test]
+    fn rejects_call_that_does_not_match_configured_arguments() {
+        let mut context = Context::test();
+        context.expect_call(
+            "TEST",
+            &["expected"],
+            ValkeyValue::SimpleString("configured".to_owned()),
+        );
+
+        assert!(matches!(
+            context.call("TEST", &["actual"]),
+            Err(crate::ValkeyError::String(message)) if message == "unexpected call: TEST actual"
+        ));
+    }
+
+    #[test]
+    fn rejects_call_that_does_not_match_configured_command() {
+        let mut context = Context::test();
+        context.expect_call(
+            "EXPECTED",
+            &["argument"],
+            ValkeyValue::SimpleString("configured".to_owned()),
+        );
+
+        assert!(matches!(
+            context.call("ACTUAL", &["argument"]),
+            Err(crate::ValkeyError::String(message))
+                if message == "unexpected call: ACTUAL argument"
+        ));
+    }
+
+    #[test]
+    fn call_ext_returns_configured_reply() {
+        let mut context = Context::test();
+        context.expect_call(
+            "ECHO",
+            &["extended"],
+            ValkeyValue::SimpleString("extended".to_owned()),
+        );
+        let options = crate::CallOptionsBuilder::new().errors_as_replies().build();
+        let reply: crate::CallResult = context.call_ext("ECHO", &options, &["extended"]);
+
+        assert_eq!(
+            ValkeyValue::from(&reply),
+            ValkeyValue::SimpleString("extended".to_owned())
+        );
+    }
+
+    #[test]
+    fn dropped_test_context_is_not_intercepted() {
+        let context = Context::test();
+        let ctx = context.context.ctx;
+        drop(context);
+
+        assert!(try_call(ctx, "TEST", &[]).is_none());
     }
 }

--- a/src/test-shims/mod.rs
+++ b/src/test-shims/mod.rs
@@ -1,8 +1,10 @@
+mod call;
 mod command_filter_ctx;
 mod context;
 mod valkey_string;
 
 pub use command_filter_ctx::TestCommandFilterCtx;
+pub(crate) use context::try_call;
 pub use context::TestContext;
 
 use crate::raw;
@@ -44,6 +46,17 @@ fn setup_test_shims() {
             raw::RedisModule_GetServerVersion = Some(context::get_server_version);
             raw::RedisModule_AuthenticateClientWithACLUser =
                 Some(context::authenticate_client_with_acl_user);
+            // Calls made through a TestContext
+            raw::RedisModule_CallReplyType = Some(call::call_reply_type);
+            raw::RedisModule_FreeCallReply = Some(call::free_call_reply);
+            raw::RedisModule_CallReplyInteger = Some(call::call_reply_integer);
+            raw::RedisModule_CallReplyBool = Some(call::call_reply_bool);
+            raw::RedisModule_CallReplyDouble = Some(call::call_reply_double);
+            raw::RedisModule_CallReplyBigNumber = Some(call::call_reply_big_number);
+            raw::RedisModule_CallReplyLength = Some(call::call_reply_length);
+            raw::RedisModule_CallReplyArrayElement = Some(call::call_reply_array_element);
+            raw::RedisModule_CallReplyMapElement = Some(call::call_reply_map_element);
+            raw::RedisModule_CallReplyStringPtr = Some(call::call_reply_string_ptr);
             // CommandFilterCtx
             raw::RedisModule_CommandFilterArgsCount =
                 Some(command_filter_ctx::command_filter_args_count);


### PR DESCRIPTION
  Adds configurable Context::call() replies for Context::test().
  - New expect_call API for exact command/argument expectations.
  - Supports scalar, array, and RESP3 map replies.
  - Unconfigured calls return descriptive errors.
-  Support shim for `ctx.config_get` which leveraged `call`

Support for `CommandFilterCtx::as_raw_ctx_ptr` to pass filter functions in unit tests
Adds documentation and unit/example coverage.