### PR TITLE
InfoContext::test shim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ valkeymodule-rs-macros/Cargo.lock
 valkeymodule-rs-macros-internals/Cargo.lock
 docs/superpowers/*
 *.profraw
+.codegraph/*

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ valkeymodule-rs-macros/Cargo.lock
 valkeymodule-rs-macros-internals/Cargo.lock
 docs/superpowers/*
 *.profraw
-.codegraph/*
+.codegraph/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cargo test
 
 ### Unit testing without a Valkey server
 
-The `test-shims` feature provides `Context::test()`, `CommandFilterCtx::test()`, and `ValkeyString::test()` for unit tests that run without starting a Valkey process. Add `valkey-module` with this feature to your development dependencies, using the same version or source as your normal dependency:
+The `test-shims` feature provides `Context::test()`, `CommandFilterCtx::test()`, `InfoContext::test()`, and `ValkeyString::test()` for unit tests that run without starting a Valkey process. Add `valkey-module` with this feature to your development dependencies, using the same version or source as your normal dependency:
 
 ```toml
 [dev-dependencies]
@@ -85,6 +85,33 @@ mod tests {
     }
 }
 ```
+
+Use `InfoContext::test()` to invoke an INFO handler directly and inspect the typed sections it emits. `sections()` returns an owned snapshot that preserves section, field, and dictionary insertion order:
+
+```rust
+use valkey_module::test_shims::{TestInfoEntry, TestInfoValue};
+use valkey_module::{InfoContext, InfoContextBuilderFieldBottomLevelValue};
+
+let info = InfoContext::test();
+info.builder()
+    .add_section("metrics")
+    .field("status", "ready")
+    .expect("status field should be unique")
+    .field("ratio", InfoContextBuilderFieldBottomLevelValue::F64(0.5))
+    .expect("ratio field should be unique")
+    .build_section()
+    .expect("section should be unique")
+    .build_info()
+    .expect("INFO data should build");
+
+assert!(matches!(
+    &info.sections()[0].entries[0],
+    TestInfoEntry::Field(field)
+        if matches!(&field.value, TestInfoValue::String(value) if value == "ready")
+));
+```
+
+Call `expect_unrequested_section(name)` before invoking a handler to model Valkey declining an unrequested INFO section. The `info_handler_builder`, `info_handler_macro`, `info_handler_multiple_sections`, `info_handler_struct`, and `test_helper` examples demonstrate serverless INFO-handler unit tests.
 
 The test context supports configuring the server version, client IDs, names, usernames, certificates, client information and IP addresses, the current user, ACL-user authentication, and client deauthentication. Configure `Context::get_server_version()` with `expect_get_server_version(major, minor, patch)`.
 
@@ -174,7 +201,7 @@ Run these tests normally:
 cargo test
 ```
 
-The first call to `Context::test()`, `CommandFilterCtx::test()`, or `ValkeyString::test()` installs process-wide test callbacks. Do not invoke the test shims inside a running Valkey process; setup rejects installation after the real Valkey API has been initialized. Only explicitly shimmed APIs work without Valkey. Other APIs, including `ValkeyString::append()`, still require a running server.
+The first call to `Context::test()`, `CommandFilterCtx::test()`, `InfoContext::test()`, or `ValkeyString::test()` installs process-wide test callbacks. Do not invoke the test shims inside a running Valkey process; setup rejects installation after the real Valkey API has been initialized. Only explicitly shimmed APIs work without Valkey. Other APIs, including `RedisModule_GetServerInfo` and `ValkeyString::append()`, still require a running server.
 
 ### Redis Compatibility
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Run these tests normally:
 cargo test
 ```
 
-The first call to `Context::test()`, `CommandFilterCtx::test()`, `InfoContext::test()`, or `ValkeyString::test()` installs process-wide test callbacks. Do not invoke the test shims inside a running Valkey process; setup rejects installation after the real Valkey API has been initialized. Only explicitly shimmed APIs work without Valkey. Other APIs, including `RedisModule_GetServerInfo` and `ValkeyString::append()`, still require a running server.
+The first call to `Context::test()`, `CommandFilterCtx::test()`, `InfoContext::test()`, or `ValkeyString::test()` installs process-wide test callbacks. Create each test context and invoke its callbacks on the same thread: live contexts are tracked in thread-local registries, so callbacks on another thread reject the context pointer as foreign. Do not invoke the test shims inside a running Valkey process; setup rejects installation after the real Valkey API has been initialized. Only explicitly shimmed APIs work without Valkey. Other APIs, including `RedisModule_GetServerInfo` and `ValkeyString::append()`, still require a running server.
 
 ### Redis Compatibility
 

--- a/examples/info_handler_builder.rs
+++ b/examples/info_handler_builder.rs
@@ -26,3 +26,45 @@ valkey_module! {
     data_types: [],
     commands: [],
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use valkey_module::test_shims::{TestInfoEntry, TestInfoField, TestInfoSection, TestInfoValue};
+
+    #[test]
+    fn captures_builder_info_and_dictionary() {
+        let info_ctx = InfoContext::test();
+
+        assert!(add_info(&info_ctx, false).is_ok());
+
+        assert_eq!(
+            info_ctx.sections(),
+            vec![TestInfoSection {
+                name: Some("info".to_owned()),
+                entries: vec![
+                    TestInfoEntry::Field(TestInfoField {
+                        name: "field".to_owned(),
+                        value: TestInfoValue::String("value".to_owned()),
+                    }),
+                    TestInfoEntry::Dictionary {
+                        name: "dictionary".to_owned(),
+                        fields: vec![TestInfoField {
+                            name: "key".to_owned(),
+                            value: TestInfoValue::String("value".to_owned()),
+                        }],
+                    },
+                ],
+            }]
+        );
+    }
+
+    #[test]
+    fn skips_unrequested_info_section() {
+        let mut info_ctx = InfoContext::test();
+        info_ctx.expect_unrequested_section("info");
+
+        assert!(add_info(&info_ctx, false).is_ok());
+        assert!(info_ctx.sections().is_empty());
+    }
+}

--- a/examples/info_handler_macro.rs
+++ b/examples/info_handler_macro.rs
@@ -22,3 +22,36 @@ valkey_module! {
     data_types: [],
     commands: [],
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use valkey_module::test_shims::{TestInfoEntry, TestInfoField, TestInfoSection, TestInfoValue};
+
+    #[test]
+    fn captures_macro_info_handler_output() {
+        let info_ctx = InfoContext::test();
+
+        assert!(add_info(&info_ctx, false).is_ok());
+
+        assert_eq!(
+            info_ctx.sections(),
+            vec![TestInfoSection {
+                name: Some("info".to_owned()),
+                entries: vec![TestInfoEntry::Field(TestInfoField {
+                    name: "field".to_owned(),
+                    value: TestInfoValue::String("value".to_owned()),
+                })],
+            }]
+        );
+    }
+
+    #[test]
+    fn skips_unrequested_info_section() {
+        let mut info_ctx = InfoContext::test();
+        info_ctx.expect_unrequested_section("info");
+
+        assert!(add_info(&info_ctx, false).is_ok());
+        assert!(info_ctx.sections().is_empty());
+    }
+}

--- a/examples/info_handler_multiple_sections.rs
+++ b/examples/info_handler_multiple_sections.rs
@@ -36,3 +36,54 @@ valkey_module! {
     data_types: [],
     commands: [],
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use valkey_module::test_shims::{TestInfoEntry, TestInfoField, TestInfoSection, TestInfoValue};
+
+    #[test]
+    fn captures_both_derived_info_sections_in_order() {
+        let info_ctx = InfoContext::test();
+
+        assert!(add_info(&info_ctx, false).is_ok());
+
+        assert_eq!(
+            info_ctx.sections(),
+            vec![
+                TestInfoSection {
+                    name: Some("InfoSection1".to_owned()),
+                    entries: vec![TestInfoEntry::Field(TestInfoField {
+                        name: "field_1".to_owned(),
+                        value: TestInfoValue::String("value1".to_owned()),
+                    })],
+                },
+                TestInfoSection {
+                    name: Some("InfoSection2".to_owned()),
+                    entries: vec![TestInfoEntry::Field(TestInfoField {
+                        name: "field_2".to_owned(),
+                        value: TestInfoValue::String("value2".to_owned()),
+                    })],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn skips_unrequested_first_info_section() {
+        let mut info_ctx = InfoContext::test();
+        info_ctx.expect_unrequested_section("InfoSection1");
+
+        assert!(add_info(&info_ctx, false).is_ok());
+        assert_eq!(
+            info_ctx.sections(),
+            vec![TestInfoSection {
+                name: Some("InfoSection2".to_owned()),
+                entries: vec![TestInfoEntry::Field(TestInfoField {
+                    name: "field_2".to_owned(),
+                    value: TestInfoValue::String("value2".to_owned()),
+                })],
+            }]
+        );
+    }
+}

--- a/examples/info_handler_struct.rs
+++ b/examples/info_handler_struct.rs
@@ -31,3 +31,45 @@ valkey_module! {
     data_types: [],
     commands: [],
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use valkey_module::test_shims::{TestInfoEntry, TestInfoField, TestInfoSection, TestInfoValue};
+
+    #[test]
+    fn captures_derived_info_struct_and_dictionary() {
+        let info_ctx = InfoContext::test();
+
+        assert!(add_info(&info_ctx, false).is_ok());
+
+        assert_eq!(
+            info_ctx.sections(),
+            vec![TestInfoSection {
+                name: Some("Info".to_owned()),
+                entries: vec![
+                    TestInfoEntry::Field(TestInfoField {
+                        name: "field".to_owned(),
+                        value: TestInfoValue::String("value".to_owned()),
+                    }),
+                    TestInfoEntry::Dictionary {
+                        name: "dictionary".to_owned(),
+                        fields: vec![TestInfoField {
+                            name: "key".to_owned(),
+                            value: TestInfoValue::String("value".to_owned()),
+                        }],
+                    },
+                ],
+            }]
+        );
+    }
+
+    #[test]
+    fn skips_unrequested_info_section() {
+        let mut info_ctx = InfoContext::test();
+        info_ctx.expect_unrequested_section("Info");
+
+        assert!(add_info(&info_ctx, false).is_ok());
+        assert!(info_ctx.sections().is_empty());
+    }
+}

--- a/examples/test_helper.rs
+++ b/examples/test_helper.rs
@@ -62,6 +62,7 @@ valkey_module! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use valkey_module::test_shims::{TestInfoEntry, TestInfoField, TestInfoSection, TestInfoValue};
     use valkey_module::ValkeyValue;
 
     #[test]
@@ -80,5 +81,32 @@ mod tests {
                 ValkeyValue::Integer(2),
             ])
         );
+    }
+
+    #[test]
+    fn captures_test_helper_info_output() {
+        let info_ctx = InfoContext::test();
+
+        assert!(add_info_impl(&info_ctx, false).is_ok());
+
+        assert_eq!(
+            info_ctx.sections(),
+            vec![TestInfoSection {
+                name: Some("test_helper".to_owned()),
+                entries: vec![TestInfoEntry::Field(TestInfoField {
+                    name: "field".to_owned(),
+                    value: TestInfoValue::String("value".to_owned()),
+                })],
+            }]
+        );
+    }
+
+    #[test]
+    fn skips_unrequested_info_section() {
+        let mut info_ctx = InfoContext::test();
+        info_ctx.expect_unrequested_section("test_helper");
+
+        assert!(add_info_impl(&info_ctx, false).is_ok());
+        assert!(info_ctx.sections().is_empty());
     }
 }

--- a/src/test-shims/call.rs
+++ b/src/test-shims/call.rs
@@ -171,7 +171,7 @@ pub(super) extern "C" fn call_reply_big_number(
             return std::ptr::null();
         };
         if !len.is_null() {
-            // SAFETY: Valkey supplies a writable length output pointer.
+            // SAFETY: The caller supplies a writable length output pointer.
             unsafe { len.write(value.len()) };
         }
         value.as_ptr().cast()
@@ -258,7 +258,7 @@ pub(super) extern "C" fn call_reply_string_ptr(
             _ => return std::ptr::null(),
         };
         if !len.is_null() {
-            // SAFETY: Valkey supplies a writable length output pointer.
+            // SAFETY: The caller supplies a writable length output pointer.
             unsafe { len.write(value.len()) };
         }
         value.as_ptr().cast()
@@ -275,9 +275,9 @@ fn with_reply_value<R>(
         return None;
     }
 
-    // SAFETY: all non-null replies originate from `TestCallReply::into_raw` or
-    // `call_reply_array_element`, which allocate a `TestCallReply` handle.
-    // SAFETY: the handle remains live for the duration of this callback.
+    // SAFETY: all non-null replies originate from `TestCallReply::into_raw` directly or from
+    // collection-element callbacks that allocate `TestCallReply` handles. The handle remains live
+    // for the duration of this callback.
     Some(f(unsafe { &*reply.cast::<TestCallReply>() }.value.as_ref()))
 }
 

--- a/src/test-shims/call.rs
+++ b/src/test-shims/call.rs
@@ -2,6 +2,22 @@ use crate::redisvalue::ValkeyValueKey;
 use crate::{raw, ValkeyValue};
 use std::sync::Arc;
 
+pub(super) fn install() {
+    // SAFETY: `setup_test_shims` calls this once after verifying the real API is uninitialized.
+    unsafe {
+        raw::RedisModule_CallReplyType = Some(call_reply_type);
+        raw::RedisModule_FreeCallReply = Some(free_call_reply);
+        raw::RedisModule_CallReplyInteger = Some(call_reply_integer);
+        raw::RedisModule_CallReplyBool = Some(call_reply_bool);
+        raw::RedisModule_CallReplyDouble = Some(call_reply_double);
+        raw::RedisModule_CallReplyBigNumber = Some(call_reply_big_number);
+        raw::RedisModule_CallReplyLength = Some(call_reply_length);
+        raw::RedisModule_CallReplyArrayElement = Some(call_reply_array_element);
+        raw::RedisModule_CallReplyMapElement = Some(call_reply_map_element);
+        raw::RedisModule_CallReplyStringPtr = Some(call_reply_string_ptr);
+    }
+}
+
 /// Owns a test-shim call reply while allowing array elements to share its value.
 #[derive(Clone)]
 pub(super) struct TestCallReply {

--- a/src/test-shims/command_filter_ctx.rs
+++ b/src/test-shims/command_filter_ctx.rs
@@ -33,12 +33,14 @@ impl CommandFilterCtx {
     }
 }
 
+/// Stores arguments and client state owned by one test command-filter context.
 struct CommandFilterData {
     args_count: libc::c_int,
     args: HashMap<libc::c_int, ValkeyString>,
     client_id: u64,
 }
 
+// Establishes the baseline state used by a newly created test command-filter context.
 impl Default for CommandFilterData {
     fn default() -> Self {
         Self {
@@ -55,6 +57,7 @@ pub struct TestCommandFilterCtx {
     data: Box<CommandFilterData>,
 }
 
+// Constructs test command-filter contexts and configures their callback values.
 impl TestCommandFilterCtx {
     fn new() -> Self {
         super::setup_test_shims();
@@ -75,6 +78,7 @@ impl TestCommandFilterCtx {
     /// Returns the opaque context pointer for invoking a command-filter callback in a test.
     ///
     /// The pointer remains valid while this test context is alive.
+    /// Invoke callbacks on the thread that created this test context.
     pub fn as_raw_ctx_ptr(&mut self) -> *mut raw::RedisModuleCommandFilterCtx {
         (self.data.as_mut() as *mut CommandFilterData).cast()
     }
@@ -279,6 +283,7 @@ fn with_data_mut<T>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Status;
 
     #[test]
     fn returns_configured_args_count() {
@@ -379,13 +384,13 @@ mod tests {
     fn rejects_null_argument_or_context() {
         assert_eq!(
             command_filter_arg_replace(null_mut(), 0, null_mut()),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
 
         let argument = ValkeyString::create_and_retain("new");
         assert_eq!(
             command_filter_arg_replace(null_mut(), 0, argument.inner),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
     }
 
@@ -434,13 +439,13 @@ mod tests {
     fn rejects_insert_with_null_argument_or_context() {
         assert_eq!(
             command_filter_arg_insert(null_mut(), 0, null_mut()),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
 
         let argument = ValkeyString::create_and_retain("new");
         assert_eq!(
             command_filter_arg_insert(null_mut(), 0, argument.inner),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
     }
 
@@ -493,7 +498,7 @@ mod tests {
     fn rejects_delete_with_null_context() {
         assert_eq!(
             command_filter_arg_delete(null_mut(), 0),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
     }
 
@@ -573,17 +578,17 @@ mod tests {
         let replacement = ValkeyString::test("replacement").take();
         assert_eq!(
             command_filter_arg_replace(ctx, 0, replacement),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
 
         let insertion = ValkeyString::test("insertion").take();
         assert_eq!(
             command_filter_arg_insert(ctx, 0, insertion),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
         assert_eq!(
             command_filter_arg_delete(ctx, 0),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
         assert_eq!(command_filter_get_client_id(ctx), DEFAULT_CLIENT_ID);
     }

--- a/src/test-shims/command_filter_ctx.rs
+++ b/src/test-shims/command_filter_ctx.rs
@@ -535,7 +535,7 @@ mod tests {
     }
 
     #[test]
-    fn callbacks_reject_dropped_context_pointer() {
+    fn callbacks_reject_dropped_context() {
         let stale = {
             let mut context = CommandFilterCtx::test();
             context
@@ -545,44 +545,46 @@ mod tests {
             context.as_raw_ctx_ptr()
         };
 
-        assert_eq!(command_filter_args_count(stale), 0);
-        assert!(command_filter_arg_get(stale, 0).is_null());
-
-        let replacement = ValkeyString::create_and_retain("replacement");
-        assert_eq!(
-            command_filter_arg_replace(stale, 0, replacement.inner),
-            raw::Status::Err as libc::c_int
-        );
-
-        let insertion = ValkeyString::create_and_retain("insertion");
-        assert_eq!(
-            command_filter_arg_insert(stale, 0, insertion.inner),
-            raw::Status::Err as libc::c_int
-        );
-        assert_eq!(
-            command_filter_arg_delete(stale, 0),
-            raw::Status::Err as libc::c_int
-        );
-        assert_eq!(command_filter_get_client_id(stale), DEFAULT_CLIENT_ID);
+        assert_command_filter_callbacks_reject(stale);
     }
 
     #[test]
-    fn callbacks_reject_unregistered_context_pointer() {
+    fn callbacks_reject_foreign_context() {
         let mut data = Box::new(CommandFilterData {
-            args_count: 7,
-            args: HashMap::new(),
+            args_count: 1,
+            args: HashMap::from([(0, ValkeyString::test("command"))]),
             client_id: 42,
         });
         let foreign =
             (data.as_mut() as *mut CommandFilterData).cast::<raw::RedisModuleCommandFilterCtx>();
 
-        assert_eq!(command_filter_args_count(foreign), 0);
-        assert!(command_filter_arg_get(foreign, 0).is_null());
-        assert_eq!(command_filter_get_client_id(foreign), DEFAULT_CLIENT_ID);
+        assert_command_filter_callbacks_reject(foreign);
     }
 
     #[test]
-    fn defaults_client_id_for_null_context() {
-        assert_eq!(command_filter_get_client_id(null_mut()), DEFAULT_CLIENT_ID);
+    fn callbacks_reject_null_context() {
+        assert_command_filter_callbacks_reject(null_mut());
+    }
+
+    fn assert_command_filter_callbacks_reject(ctx: *mut raw::RedisModuleCommandFilterCtx) {
+        assert_eq!(command_filter_args_count(ctx), 0);
+        assert!(command_filter_arg_get(ctx, 0).is_null());
+
+        let replacement = ValkeyString::test("replacement").take();
+        assert_eq!(
+            command_filter_arg_replace(ctx, 0, replacement),
+            raw::Status::Err as libc::c_int
+        );
+
+        let insertion = ValkeyString::test("insertion").take();
+        assert_eq!(
+            command_filter_arg_insert(ctx, 0, insertion),
+            raw::Status::Err as libc::c_int
+        );
+        assert_eq!(
+            command_filter_arg_delete(ctx, 0),
+            raw::Status::Err as libc::c_int
+        );
+        assert_eq!(command_filter_get_client_id(ctx), DEFAULT_CLIENT_ID);
     }
 }

--- a/src/test-shims/command_filter_ctx.rs
+++ b/src/test-shims/command_filter_ctx.rs
@@ -1,5 +1,6 @@
 use crate::{raw, CommandFilterCtx, ValkeyString};
-use std::collections::HashMap;
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::ptr::null_mut;
 
@@ -16,6 +17,13 @@ pub(super) fn install() {
 }
 
 const DEFAULT_CLIENT_ID: u64 = 1;
+
+// Tracks live test command-filter context addresses so callbacks can reject foreign or stale
+// pointers before casting them back to `CommandFilterData`. Command-filter callbacks execute
+// synchronously on the creating thread, so the registry is thread-local.
+thread_local! {
+    static TEST_COMMAND_FILTER_CONTEXTS: RefCell<HashSet<usize>> = RefCell::default();
+}
 
 impl CommandFilterCtx {
     /// Creates a test command-filter context whose API return values can be configured.
@@ -54,6 +62,9 @@ impl TestCommandFilterCtx {
         let mut data = Box::<CommandFilterData>::default();
         let inner =
             (data.as_mut() as *mut CommandFilterData).cast::<raw::RedisModuleCommandFilterCtx>();
+        TEST_COMMAND_FILTER_CONTEXTS.with(|contexts| {
+            contexts.borrow_mut().insert(inner as usize);
+        });
 
         Self {
             context: CommandFilterCtx::new(inner),
@@ -101,32 +112,36 @@ impl Deref for TestCommandFilterCtx {
     }
 }
 
+impl Drop for TestCommandFilterCtx {
+    fn drop(&mut self) {
+        let ctx = (self.data.as_mut() as *mut CommandFilterData)
+            .cast::<raw::RedisModuleCommandFilterCtx>();
+        TEST_COMMAND_FILTER_CONTEXTS.with(|contexts| {
+            contexts.borrow_mut().remove(&(ctx as usize));
+        });
+    }
+}
+
 pub(super) extern "C" fn command_filter_args_count(
     ctx: *mut raw::RedisModuleCommandFilterCtx,
 ) -> libc::c_int {
-    if ctx.is_null() {
-        return 0;
-    }
-
-    // SAFETY: `TestCommandFilterCtx::new` stores a live `CommandFilterData` allocation at this
-    // opaque pointer.
-    unsafe { &*ctx.cast::<CommandFilterData>() }.args_count
+    with_data(ctx, |data| data.args_count).unwrap_or(0)
 }
 
 pub(super) extern "C" fn command_filter_arg_get(
     ctx: *mut raw::RedisModuleCommandFilterCtx,
     position: libc::c_int,
 ) -> *mut raw::RedisModuleString {
-    if ctx.is_null() || position < 0 {
+    if position < 0 {
         return null_mut();
     }
 
-    // SAFETY: `TestCommandFilterCtx::new` stores a live `CommandFilterData` allocation at this
-    // opaque pointer.
-    let data = unsafe { &*ctx.cast::<CommandFilterData>() };
-    data.args
-        .get(&position)
-        .map_or(null_mut(), |argument| argument.inner)
+    with_data(ctx, |data| {
+        data.args
+            .get(&position)
+            .map_or(null_mut(), |argument| argument.inner)
+    })
+    .unwrap_or(null_mut())
 }
 
 pub(super) extern "C" fn command_filter_arg_replace(
@@ -141,19 +156,19 @@ pub(super) extern "C" fn command_filter_arg_replace(
     // `CommandFilterCtx::arg_replace` transfers one retained reference to the callback. Taking
     // ownership here ensures that reference is released even when the replacement is rejected.
     let argument = ValkeyString::from_redis_module_string(null_mut(), argument);
-    if ctx.is_null() || position < 0 {
+    if position < 0 {
         return raw::Status::Err as libc::c_int;
     }
 
-    // SAFETY: `TestCommandFilterCtx::new` stores a live, uniquely owned `CommandFilterData`
-    // allocation at this opaque pointer. Command-filter callbacks execute synchronously.
-    let data = unsafe { &mut *ctx.cast::<CommandFilterData>() };
-    let Some(current_argument) = data.args.get_mut(&position) else {
-        return raw::Status::Err as libc::c_int;
-    };
+    with_data_mut(ctx, |data| {
+        let Some(current_argument) = data.args.get_mut(&position) else {
+            return raw::Status::Err as libc::c_int;
+        };
 
-    *current_argument = argument;
-    raw::Status::Ok as libc::c_int
+        *current_argument = argument;
+        raw::Status::Ok as libc::c_int
+    })
+    .unwrap_or(raw::Status::Err as libc::c_int)
 }
 
 pub(super) extern "C" fn command_filter_arg_insert(
@@ -168,64 +183,97 @@ pub(super) extern "C" fn command_filter_arg_insert(
     // `CommandFilterCtx::arg_insert` transfers one retained reference to the callback. Taking
     // ownership here ensures that reference is released even when the insertion is rejected.
     let argument = ValkeyString::from_redis_module_string(null_mut(), argument);
-    if ctx.is_null() || position < 0 {
+    if position < 0 {
         return raw::Status::Err as libc::c_int;
     }
 
-    // SAFETY: `TestCommandFilterCtx::new` stores a live, uniquely owned `CommandFilterData`
-    // allocation at this opaque pointer. Command-filter callbacks execute synchronously.
-    let data = unsafe { &mut *ctx.cast::<CommandFilterData>() };
-    if data.args_count < 0 || position > data.args_count || data.args_count == libc::c_int::MAX {
-        return raw::Status::Err as libc::c_int;
-    }
-
-    for current_position in (position..data.args_count).rev() {
-        if let Some(current_argument) = data.args.remove(&current_position) {
-            data.args.insert(current_position + 1, current_argument);
+    with_data_mut(ctx, |data| {
+        if data.args_count < 0 || position > data.args_count || data.args_count == libc::c_int::MAX
+        {
+            return raw::Status::Err as libc::c_int;
         }
-    }
-    data.args.insert(position, argument);
-    data.args_count += 1;
 
-    raw::Status::Ok as libc::c_int
+        for current_position in (position..data.args_count).rev() {
+            if let Some(current_argument) = data.args.remove(&current_position) {
+                data.args.insert(current_position + 1, current_argument);
+            }
+        }
+        data.args.insert(position, argument);
+        data.args_count += 1;
+
+        raw::Status::Ok as libc::c_int
+    })
+    .unwrap_or(raw::Status::Err as libc::c_int)
 }
 
 pub(super) extern "C" fn command_filter_arg_delete(
     ctx: *mut raw::RedisModuleCommandFilterCtx,
     position: libc::c_int,
 ) -> libc::c_int {
-    if ctx.is_null() || position < 0 {
+    if position < 0 {
         return raw::Status::Err as libc::c_int;
     }
 
-    // SAFETY: `TestCommandFilterCtx::new` stores a live, uniquely owned `CommandFilterData`
-    // allocation at this opaque pointer. Command-filter callbacks execute synchronously.
-    let data = unsafe { &mut *ctx.cast::<CommandFilterData>() };
-    if position >= data.args_count {
-        return raw::Status::Err as libc::c_int;
-    }
-
-    data.args.remove(&position);
-    for current_position in position + 1..data.args_count {
-        if let Some(current_argument) = data.args.remove(&current_position) {
-            data.args.insert(current_position - 1, current_argument);
+    with_data_mut(ctx, |data| {
+        if position >= data.args_count {
+            return raw::Status::Err as libc::c_int;
         }
-    }
-    data.args_count -= 1;
 
-    raw::Status::Ok as libc::c_int
+        data.args.remove(&position);
+        for current_position in position + 1..data.args_count {
+            if let Some(current_argument) = data.args.remove(&current_position) {
+                data.args.insert(current_position - 1, current_argument);
+            }
+        }
+        data.args_count -= 1;
+
+        raw::Status::Ok as libc::c_int
+    })
+    .unwrap_or(raw::Status::Err as libc::c_int)
 }
 
 pub(super) extern "C" fn command_filter_get_client_id(
     ctx: *mut raw::RedisModuleCommandFilterCtx,
 ) -> libc::c_ulonglong {
-    if ctx.is_null() {
-        return DEFAULT_CLIENT_ID;
+    with_data(ctx, |data| data.client_id).unwrap_or(DEFAULT_CLIENT_ID)
+}
+
+/// Runs `operation` with shared access to a live test context's backing data.
+///
+/// Returns `None` when `ctx` is null, foreign, or stale.
+fn with_data<T>(
+    ctx: *mut raw::RedisModuleCommandFilterCtx,
+    operation: impl FnOnce(&CommandFilterData) -> T,
+) -> Option<T> {
+    if ctx.is_null()
+        || !TEST_COMMAND_FILTER_CONTEXTS
+            .with(|contexts| contexts.borrow().contains(&(ctx as usize)))
+    {
+        return None;
     }
 
-    // SAFETY: `TestCommandFilterCtx::new` stores a live `CommandFilterData` allocation at this
-    // opaque pointer.
-    unsafe { &*ctx.cast::<CommandFilterData>() }.client_id
+    // SAFETY: the registry contains only live `CommandFilterData` allocations, and command-filter
+    // callbacks execute synchronously on one thread.
+    Some(operation(unsafe { &*ctx.cast::<CommandFilterData>() }))
+}
+
+/// Runs `operation` with mutable access to a live test context's backing data.
+///
+/// Returns `None` when `ctx` is null, foreign, or stale.
+fn with_data_mut<T>(
+    ctx: *mut raw::RedisModuleCommandFilterCtx,
+    operation: impl FnOnce(&mut CommandFilterData) -> T,
+) -> Option<T> {
+    if ctx.is_null()
+        || !TEST_COMMAND_FILTER_CONTEXTS
+            .with(|contexts| contexts.borrow().contains(&(ctx as usize)))
+    {
+        return None;
+    }
+
+    // SAFETY: the registry contains only live, uniquely owned `CommandFilterData` allocations,
+    // and command-filter callbacks execute synchronously on one thread.
+    Some(operation(unsafe { &mut *ctx.cast::<CommandFilterData>() }))
 }
 
 #[cfg(test)]
@@ -484,6 +532,53 @@ mod tests {
         replace_argument(context.as_raw_ctx_ptr());
 
         assert_eq!(context.arg_get_try_as_str(1), Ok("new"));
+    }
+
+    #[test]
+    fn callbacks_reject_dropped_context_pointer() {
+        let stale = {
+            let mut context = CommandFilterCtx::test();
+            context
+                .expect_args_count(1)
+                .expect_arg_get(0, "command")
+                .expect_get_client_id(42);
+            context.as_raw_ctx_ptr()
+        };
+
+        assert_eq!(command_filter_args_count(stale), 0);
+        assert!(command_filter_arg_get(stale, 0).is_null());
+
+        let replacement = ValkeyString::create_and_retain("replacement");
+        assert_eq!(
+            command_filter_arg_replace(stale, 0, replacement.inner),
+            raw::Status::Err as libc::c_int
+        );
+
+        let insertion = ValkeyString::create_and_retain("insertion");
+        assert_eq!(
+            command_filter_arg_insert(stale, 0, insertion.inner),
+            raw::Status::Err as libc::c_int
+        );
+        assert_eq!(
+            command_filter_arg_delete(stale, 0),
+            raw::Status::Err as libc::c_int
+        );
+        assert_eq!(command_filter_get_client_id(stale), DEFAULT_CLIENT_ID);
+    }
+
+    #[test]
+    fn callbacks_reject_unregistered_context_pointer() {
+        let mut data = Box::new(CommandFilterData {
+            args_count: 7,
+            args: HashMap::new(),
+            client_id: 42,
+        });
+        let foreign =
+            (data.as_mut() as *mut CommandFilterData).cast::<raw::RedisModuleCommandFilterCtx>();
+
+        assert_eq!(command_filter_args_count(foreign), 0);
+        assert!(command_filter_arg_get(foreign, 0).is_null());
+        assert_eq!(command_filter_get_client_id(foreign), DEFAULT_CLIENT_ID);
     }
 
     #[test]

--- a/src/test-shims/command_filter_ctx.rs
+++ b/src/test-shims/command_filter_ctx.rs
@@ -3,6 +3,18 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::ptr::null_mut;
 
+pub(super) fn install() {
+    // SAFETY: `setup_test_shims` calls this once after verifying the real API is uninitialized.
+    unsafe {
+        raw::RedisModule_CommandFilterArgsCount = Some(command_filter_args_count);
+        raw::RedisModule_CommandFilterArgGet = Some(command_filter_arg_get);
+        raw::RedisModule_CommandFilterArgReplace = Some(command_filter_arg_replace);
+        raw::RedisModule_CommandFilterArgInsert = Some(command_filter_arg_insert);
+        raw::RedisModule_CommandFilterArgDelete = Some(command_filter_arg_delete);
+        raw::RedisModule_CommandFilterGetClientId = Some(command_filter_get_client_id);
+    }
+}
+
 const DEFAULT_CLIENT_ID: u64 = 1;
 
 impl CommandFilterCtx {

--- a/src/test-shims/context.rs
+++ b/src/test-shims/context.rs
@@ -1,14 +1,11 @@
 use super::call::TestCallReply;
 use crate::{raw, Context, RedisModuleClientInfo, ValkeyString, ValkeyValue};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::ptr::null_mut;
-use std::sync::atomic::{AtomicI32, Ordering};
 
 const DEFAULT_CLIENT_ID: u64 = 1;
-
-static SERVER_VERSION: AtomicI32 = AtomicI32::new(0);
 
 pub(super) fn install() {
     // SAFETY: `setup_test_shims` calls this once after verifying the real API is uninitialized.
@@ -32,6 +29,7 @@ pub(super) fn install() {
 thread_local! {
     static CLIENT_INFO_BY_ID: RefCell<HashMap<u64, RedisModuleClientInfo>> = RefCell::default();
     static CLIENT_NAME_BY_ID: RefCell<HashMap<u64, Vec<u8>>> = RefCell::default();
+    static SERVER_VERSION: Cell<libc::c_int> = Cell::new(0);
     static TEST_CONTEXTS: RefCell<std::collections::HashSet<usize>> = RefCell::default();
 }
 
@@ -92,6 +90,8 @@ impl TestContext {
         CLIENT_INFO_BY_ID.with(|client_info_by_id| client_info_by_id.borrow_mut().clear());
         // CLIENT_NAME_BY_ID outlives TestContext, so clear names configured by earlier tests.
         CLIENT_NAME_BY_ID.with(|client_name_by_id| client_name_by_id.borrow_mut().clear());
+        // GetServerVersion has no context parameter, so reset its per-thread expectation too.
+        SERVER_VERSION.with(|server_version| server_version.set(0));
         TEST_CONTEXTS.with(|test_contexts| {
             test_contexts.borrow_mut().insert(ctx as usize);
         });
@@ -193,7 +193,7 @@ impl TestContext {
         let version = (libc::c_int::from(major) << 16)
             | (libc::c_int::from(minor) << 8)
             | libc::c_int::from(patch);
-        SERVER_VERSION.store(version, Ordering::Relaxed);
+        SERVER_VERSION.with(|server_version| server_version.set(version));
         self
     }
 
@@ -463,7 +463,7 @@ pub(super) extern "C" fn set_module_options(_ctx: *mut raw::RedisModuleCtx, _opt
 }
 
 pub(super) extern "C" fn get_server_version() -> libc::c_int {
-    SERVER_VERSION.load(Ordering::Relaxed)
+    SERVER_VERSION.with(Cell::get)
 }
 
 pub(super) extern "C" fn authenticate_client_with_acl_user(
@@ -620,6 +620,25 @@ mod tests {
                 major: 8,
                 minor: 1,
                 patch: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn new_test_context_resets_server_version() {
+        let mut first_context = Context::test();
+        first_context.expect_get_server_version(8, 1, 2);
+
+        let second_context = Context::test();
+
+        assert_eq!(
+            second_context
+                .get_server_version()
+                .expect("default server version should be returned"),
+            raw::Version {
+                major: 0,
+                minor: 0,
+                patch: 0,
             }
         );
     }

--- a/src/test-shims/context.rs
+++ b/src/test-shims/context.rs
@@ -1,7 +1,7 @@
 use super::call::TestCallReply;
 use crate::{raw, Context, RedisModuleClientInfo, ValkeyString, ValkeyValue};
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::ptr::null_mut;
 
@@ -24,13 +24,13 @@ pub(super) fn install() {
 
 const DEFAULT_CLIENT_ID: u64 = 1;
 
-// These Valkey APIs do not receive a RedisModuleCtx, so their shims cannot access ContextData.
-// Thread-local state prevents expectations from leaking between concurrently running tests.
+// Stores expectations for APIs that cannot keep all state in `ContextData` and tracks live context
+// addresses for pointer validation. Thread-local storage isolates concurrently running tests.
 thread_local! {
     static CLIENT_INFO_BY_ID: RefCell<HashMap<u64, RedisModuleClientInfo>> = RefCell::default();
     static CLIENT_NAME_BY_ID: RefCell<HashMap<u64, Vec<u8>>> = RefCell::default();
     static SERVER_VERSION: Cell<libc::c_int> = Cell::new(0);
-    static TEST_CONTEXTS: RefCell<std::collections::HashSet<usize>> = RefCell::default();
+    static TEST_CONTEXTS: RefCell<HashSet<usize>> = RefCell::default();
 }
 
 impl Context {
@@ -41,6 +41,7 @@ impl Context {
     }
 }
 
+/// Stores expectations and mutable state owned by one test context.
 struct ContextData {
     client_id: u64,
     client_username: Option<Vec<u8>>,
@@ -58,6 +59,7 @@ struct CallExpectation {
     reply: TestCallReply,
 }
 
+// Establishes the baseline state used by a newly created test context.
 impl Default for ContextData {
     fn default() -> Self {
         Self {
@@ -78,6 +80,7 @@ pub struct TestContext {
     data: Box<ContextData>,
 }
 
+// Constructs test contexts and configures their callback expectations.
 impl TestContext {
     fn new() -> Self {
         super::setup_test_shims();
@@ -92,6 +95,7 @@ impl TestContext {
         CLIENT_NAME_BY_ID.with(|client_name_by_id| client_name_by_id.borrow_mut().clear());
         // GetServerVersion has no context parameter, so reset its per-thread expectation too.
         SERVER_VERSION.with(|server_version| server_version.set(0));
+        // Register the backing allocation before callbacks can receive its opaque context pointer.
         TEST_CONTEXTS.with(|test_contexts| {
             test_contexts.borrow_mut().insert(ctx as usize);
         });
@@ -259,7 +263,7 @@ impl Deref for TestContext {
 // Removes the context address when the backing test data is about to be released.
 impl Drop for TestContext {
     fn drop(&mut self) {
-        // A recycled allocation must not be mistaken for a live test context.
+        // Unregister the address before the backing allocation is released.
         TEST_CONTEXTS.with(|test_contexts| {
             test_contexts
                 .borrow_mut()
@@ -268,9 +272,10 @@ impl Drop for TestContext {
     }
 }
 
-/// Returns a configured reply when `ctx` belongs to a live `TestContext`.
+/// Returns a test-shim reply when `ctx` belongs to a live [`TestContext`].
 ///
-/// `None` lets ordinary contexts invoke the real Valkey API.
+/// A matching expectation returns its configured reply; an unexpected call returns an error
+/// reply. `None` lets ordinary contexts continue to the real Valkey API.
 pub(crate) fn try_call(
     ctx: *mut raw::RedisModuleCtx,
     command: &str,
@@ -334,7 +339,7 @@ pub(super) extern "C" fn set_client_name_by_id(
         return raw::Status::Err as libc::c_int;
     }
 
-    // SAFETY: Test strings passed to the shim are backed by `valkey_string::string_data`.
+    // SAFETY: The caller supplies a live module string allocated by the string shim.
     let client_name = unsafe { super::valkey_string::string_data(client_name) }.to_vec();
     let updated = CLIENT_NAME_BY_ID.with(|client_name_by_id| {
         let mut client_name_by_id = client_name_by_id.borrow_mut();
@@ -400,7 +405,7 @@ pub(super) extern "C" fn get_client_info_by_id(
         return raw::Status::Err as libc::c_int;
     };
 
-    // SAFETY: Valkey supplies a writable `RedisModuleClientInfo` output buffer.
+    // SAFETY: The caller supplies a writable `RedisModuleClientInfo` output buffer.
     unsafe {
         output.cast::<RedisModuleClientInfo>().write(client_info);
     }
@@ -513,6 +518,9 @@ fn with_data_mut<T>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{redisvalue::ValkeyValueKey, CallOptionsBuilder, CallResult, Status, ValkeyError};
+    use std::collections::BTreeMap;
+    use std::ptr::null;
 
     const TEST_CLIENT_CERTIFICATE: &str = concat!(
         "-----BEGIN CERTIFICATE-----\n",
@@ -562,7 +570,7 @@ mod tests {
 
         assert!(matches!(
             context.get_client_name_by_id(7),
-            Err(crate::ValkeyError::Str("Client/Client name is null"))
+            Err(ValkeyError::Str("Client/Client name is null"))
         ));
     }
 
@@ -597,7 +605,7 @@ mod tests {
 
         assert!(matches!(
             context.get_client_username_by_id(7),
-            Err(crate::ValkeyError::Str("Client/Username is null"))
+            Err(ValkeyError::Str("Client/Username is null"))
         ));
     }
 
@@ -665,7 +673,7 @@ mod tests {
 
         assert_eq!(
             context.authenticate_client_with_acl_user(&username),
-            raw::Status::Ok
+            Status::Ok
         );
     }
 
@@ -676,7 +684,7 @@ mod tests {
 
         assert_eq!(
             context.authenticate_client_with_acl_user(&username),
-            raw::Status::Err
+            Status::Err
         );
 
         let mut context = Context::test();
@@ -684,7 +692,7 @@ mod tests {
 
         assert_eq!(
             context.authenticate_client_with_acl_user(&username),
-            raw::Status::Err
+            Status::Err
         );
     }
 
@@ -706,35 +714,28 @@ mod tests {
             &mut client_id,
         );
 
-        assert_eq!(status, raw::Status::Ok as libc::c_int);
+        assert_eq!(status, Status::Ok as libc::c_int);
         assert_eq!(client_id, 42);
     }
 
     #[test]
     fn rejects_acl_authentication_with_null_context_or_name() {
         assert_eq!(
-            authenticate_client_with_acl_user(
-                null_mut(),
-                std::ptr::null(),
-                0,
-                None,
-                null_mut(),
-                null_mut(),
-            ),
-            raw::Status::Err as libc::c_int
+            authenticate_client_with_acl_user(null_mut(), null(), 0, None, null_mut(), null_mut(),),
+            Status::Err as libc::c_int
         );
 
         let context = Context::test();
         assert_eq!(
             authenticate_client_with_acl_user(
                 context.get_raw(),
-                std::ptr::null(),
+                null(),
                 0,
                 None,
                 null_mut(),
                 null_mut(),
             ),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
     }
 
@@ -750,7 +751,7 @@ mod tests {
 
         assert_eq!(
             context.deauthenticate_and_close_client_by_id(42),
-            raw::Status::Ok
+            Status::Ok
         );
     }
 
@@ -759,7 +760,7 @@ mod tests {
         let mut context = Context::test();
         context.expect_deauthenticate_and_close_client_by_id(42);
 
-        assert_eq!(context.deauthenticate_and_close_client(), raw::Status::Ok);
+        assert_eq!(context.deauthenticate_and_close_client(), Status::Ok);
     }
 
     #[test]
@@ -769,7 +770,7 @@ mod tests {
 
         assert_eq!(
             context.deauthenticate_and_close_client_by_id(7),
-            raw::Status::Err
+            Status::Err
         );
     }
 
@@ -779,7 +780,7 @@ mod tests {
 
         assert_eq!(
             context.deauthenticate_and_close_client_by_id(DEFAULT_CLIENT_ID),
-            raw::Status::Err
+            Status::Err
         );
     }
 
@@ -787,7 +788,7 @@ mod tests {
     fn rejects_deauthentication_with_null_context() {
         assert_eq!(
             deauthenticate_and_close_client(null_mut(), 42),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
     }
 
@@ -833,7 +834,7 @@ mod tests {
 
         assert!(matches!(
             context.get_client_info(),
-            Err(crate::ValkeyError::Str("Client/Info not found"))
+            Err(ValkeyError::Str("Client/Info not found"))
         ));
     }
 
@@ -844,7 +845,7 @@ mod tests {
 
         assert_eq!(
             get_client_info_by_id((&mut client_info as *mut RedisModuleClientInfo).cast(), 42,),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
     }
 
@@ -881,7 +882,7 @@ mod tests {
         context.expect_set_client_name_by_id(42);
         let client_name = context.create_string("bob");
 
-        assert_eq!(context.set_client_name(&client_name), raw::Status::Ok);
+        assert_eq!(context.set_client_name(&client_name), Status::Ok);
         assert_eq!(
             context
                 .get_client_name()
@@ -889,10 +890,7 @@ mod tests {
                 .as_slice(),
             b"bob"
         );
-        assert_eq!(
-            context.set_client_name_by_id(7, &client_name),
-            raw::Status::Err
-        );
+        assert_eq!(context.set_client_name_by_id(7, &client_name), Status::Err);
     }
 
     #[test]
@@ -908,11 +906,11 @@ mod tests {
 
         assert!(matches!(
             second_context.get_client_name_by_id(42),
-            Err(crate::ValkeyError::Str("Client/Client name is null"))
+            Err(ValkeyError::Str("Client/Client name is null"))
         ));
         assert!(matches!(
             second_context.get_client_info_by_id(42),
-            Err(crate::ValkeyError::Str("Client/Info not found"))
+            Err(ValkeyError::Str("Client/Info not found"))
         ));
     }
 
@@ -948,11 +946,11 @@ mod tests {
         assert!(get_client_certificate(null_mut(), 42).is_null());
         assert_eq!(
             get_client_info_by_id(null_mut(), 42),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
         assert_eq!(
             set_client_name_by_id(42, null_mut()),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
     }
 
@@ -1007,8 +1005,8 @@ mod tests {
         context.expect_call(
             "HGETALL",
             &["hash"],
-            ValkeyValue::OrderedMap(std::collections::BTreeMap::from([(
-                crate::redisvalue::ValkeyValueKey::String("field".to_owned()),
+            ValkeyValue::OrderedMap(BTreeMap::from([(
+                ValkeyValueKey::String("field".to_owned()),
                 ValkeyValue::SimpleString("value".to_owned()),
             )])),
         );
@@ -1017,8 +1015,8 @@ mod tests {
             context
                 .call("HGETALL", &["hash"])
                 .expect("configured ordered map reply should be returned"),
-            ValkeyValue::Map(std::collections::HashMap::from([(
-                crate::redisvalue::ValkeyValueKey::String("field".to_owned()),
+            ValkeyValue::Map(HashMap::from([(
+                ValkeyValueKey::String("field".to_owned()),
                 ValkeyValue::SimpleString("value".to_owned()),
             )]))
         );
@@ -1072,7 +1070,7 @@ mod tests {
 
         assert!(matches!(
             context.call("TEST", &["actual"]),
-            Err(crate::ValkeyError::String(message)) if message == "unexpected call: TEST actual"
+            Err(ValkeyError::String(message)) if message == "unexpected call: TEST actual"
         ));
     }
 
@@ -1087,7 +1085,7 @@ mod tests {
 
         assert!(matches!(
             context.call("ACTUAL", &["argument"]),
-            Err(crate::ValkeyError::String(message))
+            Err(ValkeyError::String(message))
                 if message == "unexpected call: ACTUAL argument"
         ));
     }
@@ -1100,8 +1098,8 @@ mod tests {
             &["extended"],
             ValkeyValue::SimpleString("extended".to_owned()),
         );
-        let options = crate::CallOptionsBuilder::new().errors_as_replies().build();
-        let reply: crate::CallResult = context.call_ext("ECHO", &options, &["extended"]);
+        let options = CallOptionsBuilder::new().errors_as_replies().build();
+        let reply: CallResult = context.call_ext("ECHO", &options, &["extended"]);
 
         assert_eq!(
             ValkeyValue::from(&reply),
@@ -1128,7 +1126,7 @@ mod tests {
         assert!(get_current_user_name(ctx).is_null());
         assert_eq!(
             deauthenticate_and_close_client(ctx, 42),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
         assert_eq!(
             authenticate_client_with_acl_user(
@@ -1139,7 +1137,7 @@ mod tests {
                 null_mut(),
                 &mut authenticated_client_id,
             ),
-            raw::Status::Err as libc::c_int
+            Status::Err as libc::c_int
         );
         assert_eq!(authenticated_client_id, 0);
         assert!(try_call(ctx, "TEST", &[]).is_none());

--- a/src/test-shims/context.rs
+++ b/src/test-shims/context.rs
@@ -5,8 +5,6 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::ptr::null_mut;
 
-const DEFAULT_CLIENT_ID: u64 = 1;
-
 pub(super) fn install() {
     // SAFETY: `setup_test_shims` calls this once after verifying the real API is uninitialized.
     unsafe {
@@ -23,6 +21,8 @@ pub(super) fn install() {
         raw::RedisModule_AuthenticateClientWithACLUser = Some(authenticate_client_with_acl_user);
     }
 }
+
+const DEFAULT_CLIENT_ID: u64 = 1;
 
 // These Valkey APIs do not receive a RedisModuleCtx, so their shims cannot access ContextData.
 // Thread-local state prevents expectations from leaking between concurrently running tests.
@@ -248,6 +248,14 @@ impl TestContext {
     }
 }
 
+impl Deref for TestContext {
+    type Target = Context;
+
+    fn deref(&self) -> &Self::Target {
+        &self.context
+    }
+}
+
 // Removes the context address when the backing test data is about to be released.
 impl Drop for TestContext {
     fn drop(&mut self) {
@@ -260,14 +268,6 @@ impl Drop for TestContext {
     }
 }
 
-impl Deref for TestContext {
-    type Target = Context;
-
-    fn deref(&self) -> &Self::Target {
-        &self.context
-    }
-}
-
 /// Returns a configured reply when `ctx` belongs to a live `TestContext`.
 ///
 /// `None` lets ordinary contexts invoke the real Valkey API.
@@ -276,66 +276,54 @@ pub(crate) fn try_call(
     command: &str,
     args: &[*mut raw::RedisModuleString],
 ) -> Option<*mut raw::RedisModuleCallReply> {
-    let is_test_context =
-        TEST_CONTEXTS.with(|test_contexts| test_contexts.borrow().contains(&(ctx as usize)));
-    if !is_test_context {
-        return None;
-    }
+    with_data_mut(ctx, |data| {
+        let args = args
+            .iter()
+            .map(|arg| {
+                // SAFETY: call arguments for a test context are allocated by the string test shim.
+                unsafe { super::valkey_string::string_data(*arg) }.to_vec()
+            })
+            .collect::<Vec<_>>();
+        let reply = data
+            .call_expectations
+            .iter()
+            .find(|expectation| {
+                expectation.command == command.as_bytes() && expectation.args == args
+            })
+            .map(|expectation| expectation.reply.clone());
 
-    // SAFETY: `ctx` is registered only while its owning `TestContext` is live.
-    let data = unsafe { &mut *ctx.cast::<ContextData>() };
-    let args = args
-        .iter()
-        .map(|arg| {
-            // SAFETY: call arguments for a test context are allocated by the string test shim.
-            unsafe { super::valkey_string::string_data(*arg) }.to_vec()
-        })
-        .collect::<Vec<_>>();
-    let reply = data
-        .call_expectations
-        .iter()
-        .find(|expectation| expectation.command == command.as_bytes() && expectation.args == args)
-        .map(|expectation| expectation.reply.clone());
-
-    let reply = match reply {
-        Some(reply) => reply,
-        None => TestCallReply::error(format!(
-            "unexpected call: {command} {}",
-            args.iter()
-                .map(|arg| String::from_utf8_lossy(arg))
-                .collect::<Vec<_>>()
-                .join(" ")
-        )),
-    };
-    Some(reply.into_raw())
+        let reply = match reply {
+            Some(reply) => reply,
+            None => TestCallReply::error(format!(
+                "unexpected call: {command} {}",
+                args.iter()
+                    .map(|arg| String::from_utf8_lossy(arg))
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            )),
+        };
+        reply.into_raw()
+    })
 }
 
 pub(super) extern "C" fn get_client_id(ctx: *mut raw::RedisModuleCtx) -> libc::c_ulonglong {
-    if ctx.is_null() {
-        return DEFAULT_CLIENT_ID;
-    }
-
-    // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
-    unsafe { &*ctx.cast::<ContextData>() }.client_id
+    with_data(ctx, |data| data.client_id).unwrap_or(DEFAULT_CLIENT_ID)
 }
 
 pub(super) extern "C" fn get_client_name_by_id(
     ctx: *mut raw::RedisModuleCtx,
     client_id: libc::c_ulonglong,
 ) -> *mut raw::RedisModuleString {
-    if ctx.is_null() {
-        return null_mut();
-    }
+    with_data(ctx, |_| {
+        let client_name = CLIENT_NAME_BY_ID
+            .with(|client_name_by_id| client_name_by_id.borrow().get(&client_id).cloned());
+        let Some(client_name) = client_name else {
+            return null_mut();
+        };
 
-    // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
-    let _data = unsafe { &*ctx.cast::<ContextData>() };
-    let client_name = CLIENT_NAME_BY_ID
-        .with(|client_name_by_id| client_name_by_id.borrow().get(&client_id).cloned());
-    let Some(client_name) = client_name else {
-        return null_mut();
-    };
-
-    ValkeyString::test(client_name).take()
+        ValkeyString::test(client_name).take()
+    })
+    .unwrap_or(null_mut())
 }
 
 pub(super) extern "C" fn set_client_name_by_id(
@@ -368,40 +356,34 @@ pub(super) extern "C" fn get_client_username_by_id(
     ctx: *mut raw::RedisModuleCtx,
     client_id: libc::c_ulonglong,
 ) -> *mut raw::RedisModuleString {
-    if ctx.is_null() {
-        return null_mut();
-    }
+    with_data(ctx, |data| {
+        if data.client_id != client_id {
+            return null_mut();
+        }
+        let Some(client_username) = data.client_username.as_ref() else {
+            return null_mut();
+        };
 
-    // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
-    let data = unsafe { &*ctx.cast::<ContextData>() };
-    if data.client_id != client_id {
-        return null_mut();
-    }
-    let Some(client_username) = data.client_username.as_ref() else {
-        return null_mut();
-    };
-
-    ValkeyString::test(client_username.clone()).take()
+        ValkeyString::test(client_username.clone()).take()
+    })
+    .unwrap_or(null_mut())
 }
 
 pub(super) extern "C" fn get_client_certificate(
     ctx: *mut raw::RedisModuleCtx,
     client_id: libc::c_ulonglong,
 ) -> *mut raw::RedisModuleString {
-    if ctx.is_null() {
-        return null_mut();
-    }
+    with_data(ctx, |data| {
+        if data.client_id != client_id {
+            return null_mut();
+        }
+        let Some(client_cert) = data.client_cert.as_ref() else {
+            return null_mut();
+        };
 
-    // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
-    let data = unsafe { &*ctx.cast::<ContextData>() };
-    if data.client_id != client_id {
-        return null_mut();
-    }
-    let Some(client_cert) = data.client_cert.as_ref() else {
-        return null_mut();
-    };
-
-    ValkeyString::test(client_cert.clone()).take()
+        ValkeyString::test(client_cert.clone()).take()
+    })
+    .unwrap_or(null_mut())
 }
 
 pub(super) extern "C" fn get_client_info_by_id(
@@ -428,38 +410,33 @@ pub(super) extern "C" fn get_client_info_by_id(
 pub(super) extern "C" fn get_current_user_name(
     ctx: *mut raw::RedisModuleCtx,
 ) -> *mut raw::RedisModuleString {
-    if ctx.is_null() {
-        return null_mut();
-    }
+    with_data(ctx, |data| {
+        let Some(current_user) = data.current_user.as_ref() else {
+            return null_mut();
+        };
 
-    // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
-    let data = unsafe { &*ctx.cast::<ContextData>() };
-    let Some(current_user) = data.current_user.as_ref() else {
-        return null_mut();
-    };
-
-    ValkeyString::test(current_user.clone()).take()
+        ValkeyString::test(current_user.clone()).take()
+    })
+    .unwrap_or(null_mut())
 }
 
 pub(super) extern "C" fn deauthenticate_and_close_client(
     ctx: *mut raw::RedisModuleCtx,
     client_id: libc::c_ulonglong,
 ) -> libc::c_int {
-    if ctx.is_null() {
-        return raw::Status::Err as libc::c_int;
-    }
-
-    // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
-    let data = unsafe { &*ctx.cast::<ContextData>() };
-    if data.deauthentication_expected && data.client_id == client_id {
-        raw::Status::Ok as libc::c_int
-    } else {
-        raw::Status::Err as libc::c_int
-    }
+    with_data(ctx, |data| {
+        if data.deauthentication_expected && data.client_id == client_id {
+            raw::Status::Ok as libc::c_int
+        } else {
+            raw::Status::Err as libc::c_int
+        }
+    })
+    .unwrap_or(raw::Status::Err as libc::c_int)
 }
 
 /// Accepts module options in tests without applying server-wide behavior.
-pub(super) extern "C" fn set_module_options(_ctx: *mut raw::RedisModuleCtx, _options: libc::c_int) {
+pub(super) extern "C" fn set_module_options(ctx: *mut raw::RedisModuleCtx, _options: libc::c_int) {
+    let _ = with_data(ctx, |_| ());
 }
 
 pub(super) extern "C" fn get_server_version() -> libc::c_int {
@@ -474,26 +451,63 @@ pub(super) extern "C" fn authenticate_client_with_acl_user(
     _privdata: *mut libc::c_void,
     client_id: *mut u64,
 ) -> libc::c_int {
-    if ctx.is_null() || name.is_null() {
+    if name.is_null() {
         return raw::Status::Err as libc::c_int;
     }
 
-    // SAFETY: `TestContext::new` stores a live `ContextData` allocation at this opaque pointer.
-    let data = unsafe { &*ctx.cast::<ContextData>() };
-    // SAFETY: The callback contract requires `name` to reference at least `len` readable bytes.
-    let name = unsafe { std::slice::from_raw_parts(name.cast::<u8>(), len) };
-    if data.acl_user.as_deref() != Some(name) {
-        return raw::Status::Err as libc::c_int;
-    }
-
-    if !client_id.is_null() {
-        // SAFETY: A non-null `client_id` points to writable storage supplied by the caller.
-        unsafe {
-            *client_id = data.client_id;
+    with_data(ctx, |data| {
+        // SAFETY: The callback contract requires `name` to reference at least `len` readable bytes.
+        let name = unsafe { std::slice::from_raw_parts(name.cast::<u8>(), len) };
+        if data.acl_user.as_deref() != Some(name) {
+            return raw::Status::Err as libc::c_int;
         }
+
+        if !client_id.is_null() {
+            // SAFETY: A non-null `client_id` points to writable storage supplied by the caller.
+            unsafe {
+                *client_id = data.client_id;
+            }
+        }
+
+        raw::Status::Ok as libc::c_int
+    })
+    .unwrap_or(raw::Status::Err as libc::c_int)
+}
+
+/// Runs `operation` with shared access to a live test context's backing data.
+///
+/// Returns `None` when `ctx` is null, foreign, or stale.
+fn with_data<T>(
+    ctx: *mut raw::RedisModuleCtx,
+    operation: impl FnOnce(&ContextData) -> T,
+) -> Option<T> {
+    if ctx.is_null()
+        || !TEST_CONTEXTS.with(|test_contexts| test_contexts.borrow().contains(&(ctx as usize)))
+    {
+        return None;
     }
 
-    raw::Status::Ok as libc::c_int
+    // SAFETY: the registry contains only live `ContextData` allocations, and context callbacks
+    // execute synchronously on one thread.
+    Some(operation(unsafe { &*ctx.cast::<ContextData>() }))
+}
+
+/// Runs `operation` with mutable access to a live test context's backing data.
+///
+/// Returns `None` when `ctx` is null, foreign, or stale.
+fn with_data_mut<T>(
+    ctx: *mut raw::RedisModuleCtx,
+    operation: impl FnOnce(&mut ContextData) -> T,
+) -> Option<T> {
+    if ctx.is_null()
+        || !TEST_CONTEXTS.with(|test_contexts| test_contexts.borrow().contains(&(ctx as usize)))
+    {
+        return None;
+    }
+
+    // SAFETY: the registry contains only live, uniquely owned `ContextData` allocations, and
+    // context callbacks execute synchronously on one thread.
+    Some(operation(unsafe { &mut *ctx.cast::<ContextData>() }))
 }
 
 #[cfg(test)]
@@ -943,6 +957,29 @@ mod tests {
     }
 
     #[test]
+    fn callbacks_reject_null_context() {
+        assert_context_callbacks_reject(null_mut());
+    }
+
+    #[test]
+    fn callbacks_reject_foreign_context() {
+        let mut configured_context = Context::test();
+        configured_context.expect_get_client_name_by_id(42, "alice");
+        let mut foreign_data = Box::new(ContextData {
+            client_id: 42,
+            client_username: Some(b"alice".to_vec()),
+            client_cert: Some(b"certificate".to_vec()),
+            current_user: Some(b"alice".to_vec()),
+            acl_user: Some(b"alice".to_vec()),
+            deauthentication_expected: true,
+            call_expectations: Vec::new(),
+        });
+        let foreign_ctx = (&mut *foreign_data as *mut ContextData).cast::<raw::RedisModuleCtx>();
+
+        assert_context_callbacks_reject(foreign_ctx);
+    }
+
+    #[test]
     fn returns_configured_call_reply() {
         let mut context = Context::test();
         let expected = ValkeyValue::Array(vec![
@@ -1073,11 +1110,40 @@ mod tests {
     }
 
     #[test]
-    fn dropped_test_context_is_not_intercepted() {
+    fn callbacks_reject_dropped_context() {
         let context = Context::test();
         let ctx = context.context.ctx;
         drop(context);
 
+        assert_context_callbacks_reject(ctx);
+    }
+
+    fn assert_context_callbacks_reject(ctx: *mut raw::RedisModuleCtx) {
+        let mut authenticated_client_id = 0;
+
+        assert_eq!(get_client_id(ctx), DEFAULT_CLIENT_ID);
+        assert!(get_client_name_by_id(ctx, 42).is_null());
+        assert!(get_client_username_by_id(ctx, 42).is_null());
+        assert!(get_client_certificate(ctx, 42).is_null());
+        assert!(get_current_user_name(ctx).is_null());
+        assert_eq!(
+            deauthenticate_and_close_client(ctx, 42),
+            raw::Status::Err as libc::c_int
+        );
+        assert_eq!(
+            authenticate_client_with_acl_user(
+                ctx,
+                b"alice".as_ptr().cast::<libc::c_char>(),
+                5,
+                None,
+                null_mut(),
+                &mut authenticated_client_id,
+            ),
+            raw::Status::Err as libc::c_int
+        );
+        assert_eq!(authenticated_client_id, 0);
         assert!(try_call(ctx, "TEST", &[]).is_none());
+
+        set_module_options(ctx, 0);
     }
 }

--- a/src/test-shims/context.rs
+++ b/src/test-shims/context.rs
@@ -10,6 +10,23 @@ const DEFAULT_CLIENT_ID: u64 = 1;
 
 static SERVER_VERSION: AtomicI32 = AtomicI32::new(0);
 
+pub(super) fn install() {
+    // SAFETY: `setup_test_shims` calls this once after verifying the real API is uninitialized.
+    unsafe {
+        raw::RedisModule_GetClientId = Some(get_client_id);
+        raw::RedisModule_GetClientNameById = Some(get_client_name_by_id);
+        raw::RedisModule_SetClientNameById = Some(set_client_name_by_id);
+        raw::RedisModule_GetClientUserNameById = Some(get_client_username_by_id);
+        raw::RedisModule_GetClientCertificate = Some(get_client_certificate);
+        raw::RedisModule_GetClientInfoById = Some(get_client_info_by_id);
+        raw::RedisModule_GetCurrentUserName = Some(get_current_user_name);
+        raw::RedisModule_DeauthenticateAndCloseClient = Some(deauthenticate_and_close_client);
+        raw::RedisModule_SetModuleOptions = Some(set_module_options);
+        raw::RedisModule_GetServerVersion = Some(get_server_version);
+        raw::RedisModule_AuthenticateClientWithACLUser = Some(authenticate_client_with_acl_user);
+    }
+}
+
 // These Valkey APIs do not receive a RedisModuleCtx, so their shims cannot access ContextData.
 // Thread-local state prevents expectations from leaking between concurrently running tests.
 thread_local! {

--- a/src/test-shims/info_context.rs
+++ b/src/test-shims/info_context.rs
@@ -4,6 +4,19 @@ use std::collections::HashSet;
 use std::ffi::CStr;
 use std::ops::Deref;
 
+pub(super) fn install() {
+    // SAFETY: `setup_test_shims` calls this once after verifying the real API is uninitialized.
+    unsafe {
+        raw::RedisModule_InfoAddSection = Some(info_add_section);
+        raw::RedisModule_InfoAddFieldString = Some(info_add_field_string);
+        raw::RedisModule_InfoAddFieldLongLong = Some(info_add_field_long_long);
+        raw::RedisModule_InfoAddFieldULongLong = Some(info_add_field_unsigned_long_long);
+        raw::RedisModule_InfoAddFieldDouble = Some(info_add_field_double);
+        raw::RedisModule_InfoBeginDictField = Some(info_begin_dict_field);
+        raw::RedisModule_InfoEndDictField = Some(info_end_dict_field);
+    }
+}
+
 /// A typed value captured from an INFO field.
 #[derive(Debug, Clone, PartialEq)]
 pub enum TestInfoValue {
@@ -54,6 +67,9 @@ struct InfoContextData {
     unrequested_sections: HashSet<String>,
 }
 
+// Tracks live test INFO context addresses so callbacks can reject foreign or stale pointers before
+// casting them back to `InfoContextData`. INFO callbacks execute synchronously on the creating
+// thread, so the registry is thread-local.
 thread_local! {
     static TEST_INFO_CONTEXTS: RefCell<HashSet<usize>> = RefCell::default();
 }

--- a/src/test-shims/info_context.rs
+++ b/src/test-shims/info_context.rs
@@ -73,6 +73,7 @@ pub struct TestInfoSection {
     pub entries: Vec<TestInfoEntry>,
 }
 
+/// Stores captured INFO output and the current section and dictionary positions.
 #[derive(Default)]
 struct InfoContextData {
     sections: Vec<TestInfoSection>,
@@ -88,6 +89,7 @@ pub struct TestInfoContext {
     data: Box<InfoContextData>,
 }
 
+// Constructs test INFO contexts and exposes their captured output and expectations.
 impl TestInfoContext {
     fn new() -> Self {
         super::setup_test_shims();
@@ -178,8 +180,8 @@ pub(super) extern "C" fn info_add_field_string(
         return raw::Status::Err as libc::c_int;
     }
 
-    // SAFETY: the test shim creates and owns this opaque module string for the duration of the
-    // synchronous callback.
+    // SAFETY: the caller supplies a live module string allocated by the string shim and keeps it
+    // alive for the duration of this synchronous callback.
     let value = unsafe { super::valkey_string::string_data(value) };
     let Ok(value) = String::from_utf8(value.to_vec()) else {
         return raw::Status::Err as libc::c_int;
@@ -329,6 +331,7 @@ mod tests {
         Status, ValkeyString,
     };
     use std::ffi::CString;
+    use std::ptr::{null, null_mut};
 
     #[test]
     fn captures_all_scalar_field_types() {
@@ -433,7 +436,7 @@ mod tests {
 
     #[test]
     fn callbacks_reject_null_context() {
-        assert_info_callbacks_reject(std::ptr::null_mut());
+        assert_info_callbacks_reject(null_mut());
     }
 
     #[test]
@@ -607,11 +610,11 @@ mod tests {
         let info_ctx = InfoContext::test();
 
         assert_eq!(
-            info_add_section(info_ctx.ctx, std::ptr::null()),
+            info_add_section(info_ctx.ctx, null()),
             Status::Ok as libc::c_int
         );
         assert_eq!(
-            info_add_field_long_long(info_ctx.ctx, std::ptr::null(), 1),
+            info_add_field_long_long(info_ctx.ctx, null(), 1),
             Status::Err as libc::c_int
         );
         assert!(info_ctx.sections()[0].entries.is_empty());
@@ -622,11 +625,11 @@ mod tests {
         let info_ctx = InfoContext::test();
 
         assert_eq!(
-            info_add_section(info_ctx.ctx, std::ptr::null()),
+            info_add_section(info_ctx.ctx, null()),
             Status::Ok as libc::c_int
         );
         assert_eq!(
-            info_begin_dict_field(info_ctx.ctx, std::ptr::null()),
+            info_begin_dict_field(info_ctx.ctx, null()),
             Status::Err as libc::c_int
         );
         assert!(info_ctx.sections()[0].entries.is_empty());
@@ -638,11 +641,11 @@ mod tests {
         let field = CString::new("field").expect("field name should not contain NUL");
 
         assert_eq!(
-            info_add_section(info_ctx.ctx, std::ptr::null()),
+            info_add_section(info_ctx.ctx, null()),
             Status::Ok as libc::c_int
         );
         assert_eq!(
-            info_add_field_string(info_ctx.ctx, field.as_ptr(), std::ptr::null_mut()),
+            info_add_field_string(info_ctx.ctx, field.as_ptr(), null_mut()),
             Status::Err as libc::c_int
         );
         assert!(info_ctx.sections()[0].entries.is_empty());

--- a/src/test-shims/info_context.rs
+++ b/src/test-shims/info_context.rs
@@ -17,6 +17,21 @@ pub(super) fn install() {
     }
 }
 
+// Tracks live test INFO context addresses so callbacks can reject foreign or stale pointers before
+// casting them back to `InfoContextData`. INFO callbacks execute synchronously on the creating
+// thread, so the registry is thread-local.
+thread_local! {
+    static TEST_INFO_CONTEXTS: RefCell<HashSet<usize>> = RefCell::default();
+}
+
+impl InfoContext {
+    /// Creates a test INFO context that can be used without a running Valkey server.
+    #[must_use]
+    pub fn test() -> TestInfoContext {
+        TestInfoContext::new()
+    }
+}
+
 /// A typed value captured from an INFO field.
 #[derive(Debug, Clone, PartialEq)]
 pub enum TestInfoValue {
@@ -67,25 +82,10 @@ struct InfoContextData {
     unrequested_sections: HashSet<String>,
 }
 
-// Tracks live test INFO context addresses so callbacks can reject foreign or stale pointers before
-// casting them back to `InfoContextData`. INFO callbacks execute synchronously on the creating
-// thread, so the registry is thread-local.
-thread_local! {
-    static TEST_INFO_CONTEXTS: RefCell<HashSet<usize>> = RefCell::default();
-}
-
 /// Owns a test-only [`InfoContext`] that captures emitted INFO data.
 pub struct TestInfoContext {
     context: InfoContext,
     data: Box<InfoContextData>,
-}
-
-impl InfoContext {
-    /// Creates a test INFO context that can be used without a running Valkey server.
-    #[must_use]
-    pub fn test() -> TestInfoContext {
-        TestInfoContext::new()
-    }
 }
 
 impl TestInfoContext {
@@ -131,66 +131,6 @@ impl Drop for TestInfoContext {
             contexts.borrow_mut().remove(&(self.context.ctx as usize));
         });
     }
-}
-
-fn with_data_mut<T>(
-    ctx: *mut raw::RedisModuleInfoCtx,
-    operation: impl FnOnce(&mut InfoContextData) -> T,
-) -> Option<T> {
-    if ctx.is_null()
-        || !TEST_INFO_CONTEXTS.with(|contexts| contexts.borrow().contains(&(ctx as usize)))
-    {
-        return None;
-    }
-
-    // SAFETY: the registry contains only live `InfoContextData` allocations, and INFO callbacks
-    // execute synchronously on one thread.
-    Some(operation(unsafe { &mut *ctx.cast::<InfoContextData>() }))
-}
-
-fn required_c_string(value: *const libc::c_char) -> Option<String> {
-    if value.is_null() {
-        return None;
-    }
-
-    // SAFETY: Module API callbacks require a NUL-terminated input string.
-    Some(
-        unsafe { CStr::from_ptr(value) }
-            .to_string_lossy()
-            .into_owned(),
-    )
-}
-
-fn append_field(
-    ctx: *mut raw::RedisModuleInfoCtx,
-    name: *const libc::c_char,
-    value: TestInfoValue,
-) -> libc::c_int {
-    let Some(name) = required_c_string(name) else {
-        return raw::Status::Err as libc::c_int;
-    };
-
-    with_data_mut(ctx, |data| {
-        let Some(section_index) = data.current_section else {
-            return raw::Status::Err as libc::c_int;
-        };
-        let field = TestInfoField { name, value };
-        if let Some(dictionary_index) = data.current_dictionary {
-            let Some(TestInfoEntry::Dictionary { fields, .. }) = data.sections[section_index]
-                .entries
-                .get_mut(dictionary_index)
-            else {
-                return raw::Status::Err as libc::c_int;
-            };
-            fields.push(field);
-        } else {
-            data.sections[section_index]
-                .entries
-                .push(TestInfoEntry::Field(field));
-        }
-        raw::Status::Ok as libc::c_int
-    })
-    .unwrap_or(raw::Status::Err as libc::c_int)
 }
 
 pub(super) extern "C" fn info_add_section(
@@ -311,12 +251,82 @@ pub(super) extern "C" fn info_end_dict_field(ctx: *mut raw::RedisModuleInfoCtx) 
     .unwrap_or(raw::Status::Err as libc::c_int)
 }
 
+/// Copies a required C string into an owned Rust string.
+///
+/// Returns `None` when `value` is null.
+fn required_c_string(value: *const libc::c_char) -> Option<String> {
+    if value.is_null() {
+        return None;
+    }
+
+    // SAFETY: Module API callbacks require a NUL-terminated input string.
+    Some(
+        unsafe { CStr::from_ptr(value) }
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+/// Appends a typed field to the current dictionary, or directly to the current section.
+///
+/// Returns `ERR` when the name or context is invalid, no section is active, or the current
+/// dictionary cannot accept the field.
+fn append_field(
+    ctx: *mut raw::RedisModuleInfoCtx,
+    name: *const libc::c_char,
+    value: TestInfoValue,
+) -> libc::c_int {
+    let Some(name) = required_c_string(name) else {
+        return raw::Status::Err as libc::c_int;
+    };
+
+    with_data_mut(ctx, |data| {
+        let Some(section_index) = data.current_section else {
+            return raw::Status::Err as libc::c_int;
+        };
+        let field = TestInfoField { name, value };
+        if let Some(dictionary_index) = data.current_dictionary {
+            let Some(TestInfoEntry::Dictionary { fields, .. }) = data.sections[section_index]
+                .entries
+                .get_mut(dictionary_index)
+            else {
+                return raw::Status::Err as libc::c_int;
+            };
+            fields.push(field);
+        } else {
+            data.sections[section_index]
+                .entries
+                .push(TestInfoEntry::Field(field));
+        }
+        raw::Status::Ok as libc::c_int
+    })
+    .unwrap_or(raw::Status::Err as libc::c_int)
+}
+
+/// Runs `operation` with mutable access to a live test INFO context's backing data.
+///
+/// Returns `None` when `ctx` is null, foreign, or stale.
+fn with_data_mut<T>(
+    ctx: *mut raw::RedisModuleInfoCtx,
+    operation: impl FnOnce(&mut InfoContextData) -> T,
+) -> Option<T> {
+    if ctx.is_null()
+        || !TEST_INFO_CONTEXTS.with(|contexts| contexts.borrow().contains(&(ctx as usize)))
+    {
+        return None;
+    }
+
+    // SAFETY: the registry contains only live, uniquely owned `InfoContextData` allocations, and
+    // INFO callbacks execute synchronously on one thread.
+    Some(operation(unsafe { &mut *ctx.cast::<InfoContextData>() }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
         InfoContext, InfoContextBuilderFieldBottomLevelValue, InfoContextBuilderFieldTopLevelValue,
-        Status,
+        Status, ValkeyString,
     };
     use std::ffi::CString;
 
@@ -422,23 +432,34 @@ mod tests {
     }
 
     #[test]
-    fn callbacks_reject_invalid_context() {
-        assert_eq!(
-            info_add_section(std::ptr::null_mut(), std::ptr::null()),
-            Status::Err as libc::c_int
-        );
+    fn callbacks_reject_null_context() {
+        assert_info_callbacks_reject(std::ptr::null_mut());
     }
 
     #[test]
-    fn dropped_context_pointer_is_rejected() {
+    fn callbacks_reject_foreign_context() {
+        let mut data = Box::new(InfoContextData {
+            sections: vec![TestInfoSection {
+                name: Some("section".to_owned()),
+                entries: Vec::new(),
+            }],
+            current_section: Some(0),
+            current_dictionary: None,
+            unrequested_sections: HashSet::new(),
+        });
+        let foreign = (&mut *data as *mut InfoContextData).cast::<raw::RedisModuleInfoCtx>();
+
+        assert_info_callbacks_reject(foreign);
+    }
+
+    #[test]
+    fn callbacks_reject_dropped_context() {
         let stale = {
-            let info = InfoContext::test();
-            info.ctx
+            let info_ctx = InfoContext::test();
+            info_ctx.ctx
         };
-        assert_eq!(
-            info_add_section(stale, std::ptr::null()),
-            Status::Err as libc::c_int
-        );
+
+        assert_info_callbacks_reject(stale);
     }
 
     #[test]
@@ -685,5 +706,39 @@ mod tests {
     fn rejects_invalid_dictionary_order() {
         let info = InfoContext::test();
         assert_eq!(info_end_dict_field(info.ctx), Status::Err as libc::c_int);
+    }
+
+    fn assert_info_callbacks_reject(ctx: *mut raw::RedisModuleInfoCtx) {
+        let section = CString::new("section").expect("section name should not contain NUL");
+        let field = CString::new("field").expect("field name should not contain NUL");
+        let dictionary =
+            CString::new("dictionary").expect("dictionary name should not contain NUL");
+        let value = ValkeyString::test("value");
+
+        assert_eq!(
+            info_add_section(ctx, section.as_ptr()),
+            Status::Err as libc::c_int
+        );
+        assert_eq!(
+            info_add_field_string(ctx, field.as_ptr(), value.inner),
+            Status::Err as libc::c_int
+        );
+        assert_eq!(
+            info_add_field_long_long(ctx, field.as_ptr(), 1),
+            Status::Err as libc::c_int
+        );
+        assert_eq!(
+            info_add_field_unsigned_long_long(ctx, field.as_ptr(), 1),
+            Status::Err as libc::c_int
+        );
+        assert_eq!(
+            info_add_field_double(ctx, field.as_ptr(), 1.0),
+            Status::Err as libc::c_int
+        );
+        assert_eq!(
+            info_begin_dict_field(ctx, dictionary.as_ptr()),
+            Status::Err as libc::c_int
+        );
+        assert_eq!(info_end_dict_field(ctx), Status::Err as libc::c_int);
     }
 }

--- a/src/test-shims/info_context.rs
+++ b/src/test-shims/info_context.rs
@@ -1,0 +1,673 @@
+use crate::{raw, InfoContext};
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::ffi::CStr;
+use std::ops::Deref;
+
+/// A typed value captured from an INFO field.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TestInfoValue {
+    String(String),
+    I64(i64),
+    U64(u64),
+    F64(f64),
+}
+
+/// A named INFO field captured by a test context.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TestInfoField {
+    /// The field name passed to the module API.
+    pub name: String,
+    /// The typed value emitted for the field.
+    pub value: TestInfoValue,
+}
+
+/// An entry captured within an INFO section.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TestInfoEntry {
+    /// A scalar field.
+    Field(TestInfoField),
+    /// A dictionary and its captured fields.
+    Dictionary {
+        /// The dictionary name passed to the module API.
+        name: String,
+        /// The dictionary fields in emission order.
+        fields: Vec<TestInfoField>,
+    },
+}
+
+/// An INFO section captured by a test context.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TestInfoSection {
+    /// The section name, or `None` for an unnamed section.
+    pub name: Option<String>,
+    /// The section entries in emission order.
+    pub entries: Vec<TestInfoEntry>,
+}
+
+#[derive(Default)]
+struct InfoContextData {
+    sections: Vec<TestInfoSection>,
+    current_section: Option<usize>,
+    current_dictionary: Option<usize>,
+    // Sections Valkey would reject as not requested, causing `InfoAddSection` to return `ERR`.
+    unrequested_sections: HashSet<String>,
+}
+
+thread_local! {
+    static TEST_INFO_CONTEXTS: RefCell<HashSet<usize>> = RefCell::default();
+}
+
+/// Owns a test-only [`InfoContext`] that captures emitted INFO data.
+pub struct TestInfoContext {
+    context: InfoContext,
+    data: Box<InfoContextData>,
+}
+
+impl InfoContext {
+    /// Creates a test INFO context that can be used without a running Valkey server.
+    #[must_use]
+    pub fn test() -> TestInfoContext {
+        TestInfoContext::new()
+    }
+}
+
+impl TestInfoContext {
+    fn new() -> Self {
+        super::setup_test_shims();
+
+        let mut data = Box::<InfoContextData>::default();
+        let ctx = (&mut *data as *mut InfoContextData).cast::<raw::RedisModuleInfoCtx>();
+        TEST_INFO_CONTEXTS.with(|contexts| {
+            contexts.borrow_mut().insert(ctx as usize);
+        });
+
+        Self {
+            context: InfoContext::new(ctx),
+            data,
+        }
+    }
+
+    /// Returns an owned snapshot of the INFO sections captured so far.
+    #[must_use]
+    pub fn sections(&self) -> Vec<TestInfoSection> {
+        self.data.sections.clone()
+    }
+
+    /// Configures a section as unrequested, causing `InfoAddSection` to return `ERR`.
+    pub fn expect_unrequested_section(&mut self, name: impl Into<String>) -> &mut Self {
+        self.data.unrequested_sections.insert(name.into());
+        self
+    }
+}
+
+impl Deref for TestInfoContext {
+    type Target = InfoContext;
+
+    fn deref(&self) -> &Self::Target {
+        &self.context
+    }
+}
+
+impl Drop for TestInfoContext {
+    fn drop(&mut self) {
+        TEST_INFO_CONTEXTS.with(|contexts| {
+            contexts.borrow_mut().remove(&(self.context.ctx as usize));
+        });
+    }
+}
+
+fn with_data_mut<T>(
+    ctx: *mut raw::RedisModuleInfoCtx,
+    operation: impl FnOnce(&mut InfoContextData) -> T,
+) -> Option<T> {
+    if ctx.is_null()
+        || !TEST_INFO_CONTEXTS.with(|contexts| contexts.borrow().contains(&(ctx as usize)))
+    {
+        return None;
+    }
+
+    // SAFETY: the registry contains only live `InfoContextData` allocations, and INFO callbacks
+    // execute synchronously on one thread.
+    Some(operation(unsafe { &mut *ctx.cast::<InfoContextData>() }))
+}
+
+fn required_c_string(value: *const libc::c_char) -> Option<String> {
+    if value.is_null() {
+        return None;
+    }
+
+    // SAFETY: Module API callbacks require a NUL-terminated input string.
+    Some(
+        unsafe { CStr::from_ptr(value) }
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+fn append_field(
+    ctx: *mut raw::RedisModuleInfoCtx,
+    name: *const libc::c_char,
+    value: TestInfoValue,
+) -> libc::c_int {
+    let Some(name) = required_c_string(name) else {
+        return raw::Status::Err as libc::c_int;
+    };
+
+    with_data_mut(ctx, |data| {
+        let Some(section_index) = data.current_section else {
+            return raw::Status::Err as libc::c_int;
+        };
+        let field = TestInfoField { name, value };
+        if let Some(dictionary_index) = data.current_dictionary {
+            let Some(TestInfoEntry::Dictionary { fields, .. }) = data.sections[section_index]
+                .entries
+                .get_mut(dictionary_index)
+            else {
+                return raw::Status::Err as libc::c_int;
+            };
+            fields.push(field);
+        } else {
+            data.sections[section_index]
+                .entries
+                .push(TestInfoEntry::Field(field));
+        }
+        raw::Status::Ok as libc::c_int
+    })
+    .unwrap_or(raw::Status::Err as libc::c_int)
+}
+
+pub(super) extern "C" fn info_add_section(
+    ctx: *mut raw::RedisModuleInfoCtx,
+    name: *const libc::c_char,
+) -> libc::c_int {
+    let name = if name.is_null() {
+        None
+    } else {
+        let Some(name) = required_c_string(name) else {
+            return raw::Status::Err as libc::c_int;
+        };
+        Some(name)
+    };
+
+    with_data_mut(ctx, |data| {
+        if data.current_dictionary.is_some() {
+            return raw::Status::Err as libc::c_int;
+        }
+        if name
+            .as_ref()
+            .is_some_and(|name| data.unrequested_sections.contains(name))
+        {
+            data.current_section = None;
+            data.current_dictionary = None;
+            return raw::Status::Err as libc::c_int;
+        }
+
+        data.sections.push(TestInfoSection {
+            name,
+            entries: Vec::new(),
+        });
+        data.current_section = Some(data.sections.len() - 1);
+        raw::Status::Ok as libc::c_int
+    })
+    .unwrap_or(raw::Status::Err as libc::c_int)
+}
+
+pub(super) extern "C" fn info_add_field_string(
+    ctx: *mut raw::RedisModuleInfoCtx,
+    field: *const libc::c_char,
+    value: *mut raw::RedisModuleString,
+) -> libc::c_int {
+    if value.is_null() {
+        return raw::Status::Err as libc::c_int;
+    }
+
+    // SAFETY: the test shim creates and owns this opaque module string for the duration of the
+    // synchronous callback.
+    let value = unsafe { super::valkey_string::string_data(value) };
+    let Ok(value) = String::from_utf8(value.to_vec()) else {
+        return raw::Status::Err as libc::c_int;
+    };
+    append_field(ctx, field, TestInfoValue::String(value))
+}
+
+pub(super) extern "C" fn info_add_field_long_long(
+    ctx: *mut raw::RedisModuleInfoCtx,
+    field: *const libc::c_char,
+    value: libc::c_longlong,
+) -> libc::c_int {
+    append_field(ctx, field, TestInfoValue::I64(value))
+}
+
+pub(super) extern "C" fn info_add_field_unsigned_long_long(
+    ctx: *mut raw::RedisModuleInfoCtx,
+    field: *const libc::c_char,
+    value: libc::c_ulonglong,
+) -> libc::c_int {
+    append_field(ctx, field, TestInfoValue::U64(value))
+}
+
+pub(super) extern "C" fn info_add_field_double(
+    ctx: *mut raw::RedisModuleInfoCtx,
+    field: *const libc::c_char,
+    value: libc::c_double,
+) -> libc::c_int {
+    append_field(ctx, field, TestInfoValue::F64(value))
+}
+
+pub(super) extern "C" fn info_begin_dict_field(
+    ctx: *mut raw::RedisModuleInfoCtx,
+    name: *const libc::c_char,
+) -> libc::c_int {
+    let Some(name) = required_c_string(name) else {
+        return raw::Status::Err as libc::c_int;
+    };
+
+    with_data_mut(ctx, |data| {
+        let Some(section_index) = data.current_section else {
+            return raw::Status::Err as libc::c_int;
+        };
+        if data.current_dictionary.is_some() {
+            return raw::Status::Err as libc::c_int;
+        }
+
+        let dictionary_index = data.sections[section_index].entries.len();
+        data.sections[section_index]
+            .entries
+            .push(TestInfoEntry::Dictionary {
+                name,
+                fields: Vec::new(),
+            });
+        data.current_dictionary = Some(dictionary_index);
+        raw::Status::Ok as libc::c_int
+    })
+    .unwrap_or(raw::Status::Err as libc::c_int)
+}
+
+pub(super) extern "C" fn info_end_dict_field(ctx: *mut raw::RedisModuleInfoCtx) -> libc::c_int {
+    with_data_mut(ctx, |data| {
+        if data.current_dictionary.take().is_some() {
+            raw::Status::Ok as libc::c_int
+        } else {
+            raw::Status::Err as libc::c_int
+        }
+    })
+    .unwrap_or(raw::Status::Err as libc::c_int)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        InfoContext, InfoContextBuilderFieldBottomLevelValue, InfoContextBuilderFieldTopLevelValue,
+        Status,
+    };
+    use std::ffi::CString;
+
+    #[test]
+    fn captures_all_scalar_field_types() {
+        let info = InfoContext::test();
+
+        info.builder()
+            .add_section("metrics")
+            .field("text", "ready")
+            .expect("text field should be unique")
+            .field("signed", -7_i64)
+            .expect("signed field should be unique")
+            .field("unsigned", 8_u64)
+            .expect("unsigned field should be unique")
+            .field("ratio", InfoContextBuilderFieldBottomLevelValue::F64(1.25))
+            .expect("ratio field should be unique")
+            .build_section()
+            .expect("section should be unique")
+            .build_info()
+            .expect("shim should accept INFO fields");
+
+        assert_eq!(
+            info.sections(),
+            vec![TestInfoSection {
+                name: Some("metrics".to_owned()),
+                entries: vec![
+                    TestInfoEntry::Field(TestInfoField {
+                        name: "text".to_owned(),
+                        value: TestInfoValue::String("ready".to_owned()),
+                    }),
+                    TestInfoEntry::Field(TestInfoField {
+                        name: "signed".to_owned(),
+                        value: TestInfoValue::I64(-7),
+                    }),
+                    TestInfoEntry::Field(TestInfoField {
+                        name: "unsigned".to_owned(),
+                        value: TestInfoValue::U64(8),
+                    }),
+                    TestInfoEntry::Field(TestInfoField {
+                        name: "ratio".to_owned(),
+                        value: TestInfoValue::F64(1.25),
+                    }),
+                ],
+            }]
+        );
+
+        #[allow(deprecated)]
+        {
+            let direct = InfoContext::test();
+            assert_eq!(direct.add_info_section(None), Status::Ok);
+            assert_eq!(direct.add_info_field_str("state", "ok"), Status::Ok);
+            assert_eq!(direct.add_info_field_long_long("count", -2), Status::Ok);
+            assert_eq!(direct.sections()[0].name, None);
+        }
+    }
+
+    #[test]
+    fn captures_build_one_section_and_preserves_section_order() {
+        let info = InfoContext::test();
+        info.build_one_section((
+            "first".to_owned(),
+            vec![(
+                "value".to_owned(),
+                InfoContextBuilderFieldTopLevelValue::from(1_i64),
+            )],
+        ))
+        .expect("first section should build");
+        info.build_one_section((
+            "second".to_owned(),
+            vec![(
+                "value".to_owned(),
+                InfoContextBuilderFieldTopLevelValue::from(2_u64),
+            )],
+        ))
+        .expect("second section should build");
+
+        assert_eq!(
+            info.sections()
+                .iter()
+                .map(|section| section.name.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("first"), Some("second")]
+        );
+    }
+
+    #[test]
+    fn test_info_contexts_do_not_share_output() {
+        let first = InfoContext::test();
+        first
+            .build_one_section((
+                "first".to_owned(),
+                vec![(
+                    "value".to_owned(),
+                    InfoContextBuilderFieldTopLevelValue::from(1_i64),
+                )],
+            ))
+            .expect("first context should capture output");
+
+        let second = InfoContext::test();
+        assert!(second.sections().is_empty());
+        assert_eq!(first.sections().len(), 1);
+    }
+
+    #[test]
+    fn callbacks_reject_invalid_context() {
+        assert_eq!(
+            info_add_section(std::ptr::null_mut(), std::ptr::null()),
+            Status::Err as libc::c_int
+        );
+    }
+
+    #[test]
+    fn dropped_context_pointer_is_rejected() {
+        let stale = {
+            let info = InfoContext::test();
+            info.ctx
+        };
+        assert_eq!(
+            info_add_section(stale, std::ptr::null()),
+            Status::Err as libc::c_int
+        );
+    }
+
+    #[test]
+    fn captures_dictionary_fields() {
+        let info = InfoContext::test();
+
+        info.builder()
+            .add_section("keyspace")
+            .add_dictionary("db0")
+            .field("keys", 12_u64)
+            .expect("keys field should be unique")
+            .field("expires", 3_i64)
+            .expect("expires field should be unique")
+            .field("status", "ready")
+            .expect("status field should be unique")
+            .field("ratio", InfoContextBuilderFieldBottomLevelValue::F64(0.25))
+            .expect("ratio field should be unique")
+            .build_dictionary()
+            .expect("dictionary should build")
+            .build_section()
+            .expect("section should build")
+            .build_info()
+            .expect("INFO data should build");
+
+        assert_eq!(
+            info.sections()[0].entries,
+            vec![TestInfoEntry::Dictionary {
+                name: "db0".to_owned(),
+                fields: vec![
+                    TestInfoField {
+                        name: "keys".to_owned(),
+                        value: TestInfoValue::U64(12),
+                    },
+                    TestInfoField {
+                        name: "expires".to_owned(),
+                        value: TestInfoValue::I64(3),
+                    },
+                    TestInfoField {
+                        name: "status".to_owned(),
+                        value: TestInfoValue::String("ready".to_owned()),
+                    },
+                    TestInfoField {
+                        name: "ratio".to_owned(),
+                        value: TestInfoValue::F64(0.25),
+                    },
+                ],
+            }]
+        );
+    }
+
+    #[test]
+    fn skips_sections_configured_as_unrequested() {
+        let mut info = InfoContext::test();
+        info.expect_unrequested_section("hidden");
+
+        info.builder()
+            .add_section("hidden")
+            .field("ignored", 1_i64)
+            .expect("ignored field should be unique")
+            .build_section()
+            .expect("section definition should be valid")
+            .add_section("visible")
+            .field("kept", 2_i64)
+            .expect("kept field should be unique")
+            .build_section()
+            .expect("section definition should be valid")
+            .build_info()
+            .expect("unrequested sections should be skipped");
+
+        assert_eq!(info.sections().len(), 1);
+        assert_eq!(info.sections()[0].name.as_deref(), Some("visible"));
+    }
+
+    #[test]
+    fn rejects_field_before_section() {
+        let info_ctx = InfoContext::test();
+        let field = CString::new("field").expect("field name should not contain NUL");
+
+        assert_eq!(
+            info_add_field_long_long(info_ctx.ctx, field.as_ptr(), 1),
+            Status::Err as libc::c_int
+        );
+        assert!(info_ctx.sections().is_empty());
+    }
+
+    #[test]
+    fn rejects_dictionary_before_section() {
+        let info_ctx = InfoContext::test();
+        let dictionary =
+            CString::new("dictionary").expect("dictionary name should not contain NUL");
+
+        assert_eq!(
+            info_begin_dict_field(info_ctx.ctx, dictionary.as_ptr()),
+            Status::Err as libc::c_int
+        );
+        assert!(info_ctx.sections().is_empty());
+    }
+
+    #[test]
+    fn rejects_nested_dictionary() {
+        let info_ctx = InfoContext::test();
+        let section = CString::new("section").expect("section name should not contain NUL");
+        let outer = CString::new("outer").expect("dictionary name should not contain NUL");
+        let nested = CString::new("nested").expect("dictionary name should not contain NUL");
+
+        assert_eq!(
+            info_add_section(info_ctx.ctx, section.as_ptr()),
+            Status::Ok as libc::c_int
+        );
+        assert_eq!(
+            info_begin_dict_field(info_ctx.ctx, outer.as_ptr()),
+            Status::Ok as libc::c_int
+        );
+        assert_eq!(
+            info_begin_dict_field(info_ctx.ctx, nested.as_ptr()),
+            Status::Err as libc::c_int
+        );
+    }
+
+    #[test]
+    fn rejects_new_section_while_dictionary_is_open() {
+        let info_ctx = InfoContext::test();
+        let first_section = CString::new("first").expect("section name should not contain NUL");
+        let second_section = CString::new("second").expect("section name should not contain NUL");
+        let dictionary =
+            CString::new("dictionary").expect("dictionary name should not contain NUL");
+
+        assert_eq!(
+            info_add_section(info_ctx.ctx, first_section.as_ptr()),
+            Status::Ok as libc::c_int
+        );
+        assert_eq!(
+            info_begin_dict_field(info_ctx.ctx, dictionary.as_ptr()),
+            Status::Ok as libc::c_int
+        );
+        assert_eq!(
+            info_add_section(info_ctx.ctx, second_section.as_ptr()),
+            Status::Err as libc::c_int
+        );
+        assert_eq!(info_ctx.sections().len(), 1);
+    }
+
+    #[test]
+    fn rejects_null_field_name() {
+        let info_ctx = InfoContext::test();
+
+        assert_eq!(
+            info_add_section(info_ctx.ctx, std::ptr::null()),
+            Status::Ok as libc::c_int
+        );
+        assert_eq!(
+            info_add_field_long_long(info_ctx.ctx, std::ptr::null(), 1),
+            Status::Err as libc::c_int
+        );
+        assert!(info_ctx.sections()[0].entries.is_empty());
+    }
+
+    #[test]
+    fn rejects_null_dictionary_name() {
+        let info_ctx = InfoContext::test();
+
+        assert_eq!(
+            info_add_section(info_ctx.ctx, std::ptr::null()),
+            Status::Ok as libc::c_int
+        );
+        assert_eq!(
+            info_begin_dict_field(info_ctx.ctx, std::ptr::null()),
+            Status::Err as libc::c_int
+        );
+        assert!(info_ctx.sections()[0].entries.is_empty());
+    }
+
+    #[test]
+    fn rejects_null_string_value() {
+        let info_ctx = InfoContext::test();
+        let field = CString::new("field").expect("field name should not contain NUL");
+
+        assert_eq!(
+            info_add_section(info_ctx.ctx, std::ptr::null()),
+            Status::Ok as libc::c_int
+        );
+        assert_eq!(
+            info_add_field_string(info_ctx.ctx, field.as_ptr(), std::ptr::null_mut()),
+            Status::Err as libc::c_int
+        );
+        assert!(info_ctx.sections()[0].entries.is_empty());
+    }
+
+    #[test]
+    fn rejects_field_after_unrequested_section() {
+        let mut info_ctx = InfoContext::test();
+        info_ctx.expect_unrequested_section("hidden");
+        let section = CString::new("hidden").expect("section name should not contain NUL");
+        let field = CString::new("field").expect("field name should not contain NUL");
+
+        assert_eq!(
+            info_add_section(info_ctx.ctx, section.as_ptr()),
+            Status::Err as libc::c_int
+        );
+        assert_eq!(
+            info_add_field_long_long(info_ctx.ctx, field.as_ptr(), 1),
+            Status::Err as libc::c_int
+        );
+        assert!(info_ctx.sections().is_empty());
+    }
+
+    #[test]
+    fn accepts_scalar_field_after_dictionary_ends() {
+        let info_ctx = InfoContext::test();
+        let section = CString::new("section").expect("section name should not contain NUL");
+        let dictionary =
+            CString::new("dictionary").expect("dictionary name should not contain NUL");
+        let field = CString::new("field").expect("field name should not contain NUL");
+
+        assert_eq!(
+            info_add_section(info_ctx.ctx, section.as_ptr()),
+            Status::Ok as libc::c_int
+        );
+        assert_eq!(
+            info_begin_dict_field(info_ctx.ctx, dictionary.as_ptr()),
+            Status::Ok as libc::c_int
+        );
+        assert_eq!(info_end_dict_field(info_ctx.ctx), Status::Ok as libc::c_int);
+        assert_eq!(
+            info_add_field_long_long(info_ctx.ctx, field.as_ptr(), 1),
+            Status::Ok as libc::c_int
+        );
+        assert_eq!(
+            info_ctx.sections()[0].entries,
+            vec![
+                TestInfoEntry::Dictionary {
+                    name: "dictionary".to_owned(),
+                    fields: Vec::new(),
+                },
+                TestInfoEntry::Field(TestInfoField {
+                    name: "field".to_owned(),
+                    value: TestInfoValue::I64(1),
+                }),
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_dictionary_order() {
+        let info = InfoContext::test();
+        assert_eq!(info_end_dict_field(info.ctx), Status::Err as libc::c_int);
+    }
+}

--- a/src/test-shims/mod.rs
+++ b/src/test-shims/mod.rs
@@ -1,11 +1,15 @@
 mod call;
 mod command_filter_ctx;
 mod context;
+mod info_context;
 mod valkey_string;
 
 pub use command_filter_ctx::TestCommandFilterCtx;
 pub(crate) use context::try_call;
 pub use context::TestContext;
+pub use info_context::{
+    TestInfoContext, TestInfoEntry, TestInfoField, TestInfoSection, TestInfoValue,
+};
 
 use crate::raw;
 use std::ptr::addr_of;
@@ -57,6 +61,15 @@ fn setup_test_shims() {
             raw::RedisModule_CallReplyArrayElement = Some(call::call_reply_array_element);
             raw::RedisModule_CallReplyMapElement = Some(call::call_reply_map_element);
             raw::RedisModule_CallReplyStringPtr = Some(call::call_reply_string_ptr);
+            // InfoContext
+            raw::RedisModule_InfoAddSection = Some(info_context::info_add_section);
+            raw::RedisModule_InfoAddFieldString = Some(info_context::info_add_field_string);
+            raw::RedisModule_InfoAddFieldLongLong = Some(info_context::info_add_field_long_long);
+            raw::RedisModule_InfoAddFieldULongLong =
+                Some(info_context::info_add_field_unsigned_long_long);
+            raw::RedisModule_InfoAddFieldDouble = Some(info_context::info_add_field_double);
+            raw::RedisModule_InfoBeginDictField = Some(info_context::info_begin_dict_field);
+            raw::RedisModule_InfoEndDictField = Some(info_context::info_end_dict_field);
             // CommandFilterCtx
             raw::RedisModule_CommandFilterArgsCount =
                 Some(command_filter_ctx::command_filter_args_count);

--- a/src/test-shims/mod.rs
+++ b/src/test-shims/mod.rs
@@ -24,65 +24,11 @@ fn setup_test_shims() {
             "refusing to install test shims inside a running Valkey process"
         );
 
-        unsafe {
-            // ValkeyString
-            raw::RedisModule_StringPtrLen = Some(valkey_string::string_ptr_len);
-            raw::RedisModule_FreeString = Some(valkey_string::free_string);
-            raw::RedisModule_RetainString = Some(valkey_string::retain_string);
-            raw::RedisModule_StringToLongLong = Some(valkey_string::string_to_longlong);
-            raw::RedisModule_StringToULongLong = Some(valkey_string::string_to_ulonglong);
-            raw::RedisModule_StringToDouble = Some(valkey_string::string_to_double);
-            raw::RedisModule_CreateString = Some(valkey_string::create_string);
-            raw::RedisModule_CreateStringFromString =
-                Some(valkey_string::create_string_from_string);
-            raw::RedisModule_StringCompare = Some(valkey_string::string_compare);
-            // Context
-            raw::RedisModule_GetClientId = Some(context::get_client_id);
-            raw::RedisModule_GetClientNameById = Some(context::get_client_name_by_id);
-            raw::RedisModule_SetClientNameById = Some(context::set_client_name_by_id);
-            raw::RedisModule_GetClientUserNameById = Some(context::get_client_username_by_id);
-            raw::RedisModule_GetClientCertificate = Some(context::get_client_certificate);
-            raw::RedisModule_GetClientInfoById = Some(context::get_client_info_by_id);
-            raw::RedisModule_GetCurrentUserName = Some(context::get_current_user_name);
-            raw::RedisModule_DeauthenticateAndCloseClient =
-                Some(context::deauthenticate_and_close_client);
-            raw::RedisModule_SetModuleOptions = Some(context::set_module_options);
-            raw::RedisModule_GetServerVersion = Some(context::get_server_version);
-            raw::RedisModule_AuthenticateClientWithACLUser =
-                Some(context::authenticate_client_with_acl_user);
-            // Calls made through a TestContext
-            raw::RedisModule_CallReplyType = Some(call::call_reply_type);
-            raw::RedisModule_FreeCallReply = Some(call::free_call_reply);
-            raw::RedisModule_CallReplyInteger = Some(call::call_reply_integer);
-            raw::RedisModule_CallReplyBool = Some(call::call_reply_bool);
-            raw::RedisModule_CallReplyDouble = Some(call::call_reply_double);
-            raw::RedisModule_CallReplyBigNumber = Some(call::call_reply_big_number);
-            raw::RedisModule_CallReplyLength = Some(call::call_reply_length);
-            raw::RedisModule_CallReplyArrayElement = Some(call::call_reply_array_element);
-            raw::RedisModule_CallReplyMapElement = Some(call::call_reply_map_element);
-            raw::RedisModule_CallReplyStringPtr = Some(call::call_reply_string_ptr);
-            // InfoContext
-            raw::RedisModule_InfoAddSection = Some(info_context::info_add_section);
-            raw::RedisModule_InfoAddFieldString = Some(info_context::info_add_field_string);
-            raw::RedisModule_InfoAddFieldLongLong = Some(info_context::info_add_field_long_long);
-            raw::RedisModule_InfoAddFieldULongLong =
-                Some(info_context::info_add_field_unsigned_long_long);
-            raw::RedisModule_InfoAddFieldDouble = Some(info_context::info_add_field_double);
-            raw::RedisModule_InfoBeginDictField = Some(info_context::info_begin_dict_field);
-            raw::RedisModule_InfoEndDictField = Some(info_context::info_end_dict_field);
-            // CommandFilterCtx
-            raw::RedisModule_CommandFilterArgsCount =
-                Some(command_filter_ctx::command_filter_args_count);
-            raw::RedisModule_CommandFilterArgGet = Some(command_filter_ctx::command_filter_arg_get);
-            raw::RedisModule_CommandFilterArgReplace =
-                Some(command_filter_ctx::command_filter_arg_replace);
-            raw::RedisModule_CommandFilterArgInsert =
-                Some(command_filter_ctx::command_filter_arg_insert);
-            raw::RedisModule_CommandFilterArgDelete =
-                Some(command_filter_ctx::command_filter_arg_delete);
-            raw::RedisModule_CommandFilterGetClientId =
-                Some(command_filter_ctx::command_filter_get_client_id);
-        }
+        valkey_string::install();
+        context::install();
+        call::install();
+        info_context::install();
+        command_filter_ctx::install();
     });
 }
 

--- a/src/test-shims/valkey_string.rs
+++ b/src/test-shims/valkey_string.rs
@@ -5,6 +5,21 @@ use std::ptr::null_mut;
 use std::str::FromStr;
 use std::sync::Arc;
 
+pub(super) fn install() {
+    // SAFETY: `setup_test_shims` calls this once after verifying the real API is uninitialized.
+    unsafe {
+        raw::RedisModule_StringPtrLen = Some(string_ptr_len);
+        raw::RedisModule_FreeString = Some(free_string);
+        raw::RedisModule_RetainString = Some(retain_string);
+        raw::RedisModule_StringToLongLong = Some(string_to_longlong);
+        raw::RedisModule_StringToULongLong = Some(string_to_ulonglong);
+        raw::RedisModule_StringToDouble = Some(string_to_double);
+        raw::RedisModule_CreateString = Some(create_string);
+        raw::RedisModule_CreateStringFromString = Some(create_string_from_string);
+        raw::RedisModule_StringCompare = Some(string_compare);
+    }
+}
+
 type ShimString = Vec<u8>;
 
 impl ValkeyString {

--- a/src/test-shims/valkey_string.rs
+++ b/src/test-shims/valkey_string.rs
@@ -43,7 +43,7 @@ pub(super) extern "C" fn string_ptr_len(
     string: *const raw::RedisModuleString,
     len: *mut usize,
 ) -> *const c_char {
-    // SAFETY: The shim is installed only for pointers created by `into_raw_string`.
+    // SAFETY: The caller supplies a live module-string pointer created by `into_raw_string`.
     let data = unsafe { string_data(string) };
     // SAFETY: `ValkeyString` supplies a non-null pointer to writable length storage.
     unsafe {


### PR DESCRIPTION
  - Add InfoContext::test() with typed capture of INFO sections, fields, and dictionaries.
  - Shim all INFO APIs used by the SDK, including unrequested-section behavior and error paths.
  - Add serverless tests for five INFO examples.
  - Move callback installation into each test-shim module.
  - Add a thread-local registry of live TestCommandFilterCtx pointers
  - Moved Context SERVER_VERSION to thread_local! registry 
  - Standardized TestInfoContext, TestCommandFilterCtx and TestContext shims structure