### PR TITLE
Test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,10 @@ context
 
 rewrite_set(&context);
 
-assert_eq!(context.args_count(), 3);
-assert_eq!(context.arg_get_try_as_str(1), Ok("new-key"));
+assert_eq!(
+    context.args(),
+    vec![b"SET".as_slice(), b"new-key", b"value"]
+);
 assert_eq!(context.get_client_id(), 42);
 ```
 
@@ -210,10 +212,13 @@ context.expect_args(&["SET", "key", "value"]);
 
 rewrite_set_filter(context.as_raw_ctx_ptr());
 
-assert_eq!(context.arg_get_try_as_str(1), Ok("new-key"));
+assert_eq!(
+    context.args(),
+    vec![b"SET".as_slice(), b"new-key", b"value"]
+);
 ```
 
-`expect_args()` configures the complete binary-safe argument list and its reported count. Use `expect_args_count()` and `expect_arg_get()` when a test needs to configure those values independently. The test context also supports command lookup, client ID lookup, and argument replacement, insertion, and deletion. Insertions and deletions update the argument count and shift subsequent arguments.
+`expect_args()` configures the complete binary-safe argument list and its reported count, while `args()` returns the current list in position order for assertions. Use `expect_args_count()` and `expect_arg_get()` when a test needs to configure those values independently. The test context also supports command lookup, client ID lookup, and argument replacement, insertion, and deletion. Insertions and deletions update the argument count and shift subsequent arguments.
 
 Run these tests normally:
 

--- a/README.md
+++ b/README.md
@@ -185,10 +185,7 @@ fn rewrite_set(context: &CommandFilterCtx) {
 
 let mut context = CommandFilterCtx::test();
 context
-    .expect_args_count(3)
-    .expect_arg_get(0, "SET")
-    .expect_arg_get(1, "key")
-    .expect_arg_get(2, "value")
+    .expect_args(&["SET", "key", "value"])
     .expect_get_client_id(42);
 
 rewrite_set(&context);
@@ -209,18 +206,14 @@ fn rewrite_set_filter(ctx: *mut RedisModuleCommandFilterCtx) {
 }
 
 let mut context = CommandFilterCtx::test();
-context
-    .expect_args_count(3)
-    .expect_arg_get(0, "SET")
-    .expect_arg_get(1, "key")
-    .expect_arg_get(2, "value");
+context.expect_args(&["SET", "key", "value"]);
 
 rewrite_set_filter(context.as_raw_ctx_ptr());
 
 assert_eq!(context.arg_get_try_as_str(1), Ok("new-key"));
 ```
 
-`expect_args_count()` configures the reported number of arguments, while `expect_arg_get()` configures the binary-safe value at an individual position. The test context also supports command lookup, client ID lookup, and argument replacement, insertion, and deletion. Insertions and deletions update the argument count and shift subsequent arguments.
+`expect_args()` configures the complete binary-safe argument list and its reported count. Use `expect_args_count()` and `expect_arg_get()` when a test needs to configure those values independently. The test context also supports command lookup, client ID lookup, and argument replacement, insertion, and deletion. Insertions and deletions update the argument count and shift subsequent arguments.
 
 Run these tests normally:
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ mod tests {
 }
 ```
 
+Use `test_shims::create_test_args()` to convert text or binary values implementing `AsRef<[u8]>` into a `Vec<ValkeyString>`:
+
+```rust
+use valkey_module::test_shims::create_test_args;
+
+let args = create_test_args(&["example.command", "first", "second"]);
+let binary_args = create_test_args(&[b"example.command".as_slice(), b"\0\xff".as_slice()]);
+```
+
 Use `InfoContext::test()` to invoke an INFO handler directly and inspect the typed sections it emits. `sections()` returns an owned snapshot that preserves section, field, and dictionary insertion order:
 
 ```rust

--- a/examples/filter1.rs
+++ b/examples/filter1.rs
@@ -118,10 +118,7 @@ mod tests {
     #[test]
     fn info_filter_rewrites_info_command() {
         let mut context = CommandFilterCtx::test();
-        context
-            .expect_args_count(1)
-            .expect_arg_get(0, "INFO")
-            .expect_get_client_id(42);
+        context.expect_args(&["INFO"]).expect_get_client_id(42);
 
         info_filter_fn(context.as_raw_ctx_ptr());
 
@@ -131,7 +128,7 @@ mod tests {
     #[test]
     fn info_filter_leaves_unrelated_command_unchanged() {
         let mut context = CommandFilterCtx::test();
-        context.expect_args_count(1).expect_arg_get(0, "PING");
+        context.expect_args(&["PING"]);
 
         info_filter_fn(context.as_raw_ctx_ptr());
 
@@ -141,11 +138,7 @@ mod tests {
     #[test]
     fn set_filter_rewrites_key_and_value() {
         let mut context = CommandFilterCtx::test();
-        context
-            .expect_args_count(3)
-            .expect_arg_get(0, "SET")
-            .expect_arg_get(1, "old_key")
-            .expect_arg_get(2, "old_value");
+        context.expect_args(&["SET", "old_key", "old_value"]);
 
         set_filter_fn(context.as_raw_ctx_ptr());
 
@@ -158,10 +151,7 @@ mod tests {
     #[test]
     fn set_filter_leaves_wrong_arity_unchanged() {
         let mut context = CommandFilterCtx::test();
-        context
-            .expect_args_count(2)
-            .expect_arg_get(0, "SET")
-            .expect_arg_get(1, "key");
+        context.expect_args(&["SET", "key"]);
 
         set_filter_fn(context.as_raw_ctx_ptr());
 
@@ -173,11 +163,7 @@ mod tests {
     #[test]
     fn set_filter_leaves_unrelated_command_unchanged() {
         let mut context = CommandFilterCtx::test();
-        context
-            .expect_args_count(3)
-            .expect_arg_get(0, "GET")
-            .expect_arg_get(1, "key")
-            .expect_arg_get(2, "value");
+        context.expect_args(&["GET", "key", "value"]);
 
         set_filter_fn(context.as_raw_ctx_ptr());
 

--- a/examples/filter1.rs
+++ b/examples/filter1.rs
@@ -122,7 +122,7 @@ mod tests {
 
         info_filter_fn(context.as_raw_ctx_ptr());
 
-        assert_eq!(context.cmd_get_try_as_str(), Ok("info2"));
+        assert_eq!(context.args(), vec![b"info2".as_slice()]);
     }
 
     #[test]
@@ -132,7 +132,7 @@ mod tests {
 
         info_filter_fn(context.as_raw_ctx_ptr());
 
-        assert_eq!(context.cmd_get_try_as_str(), Ok("PING"));
+        assert_eq!(context.args(), vec![b"PING".as_slice()]);
     }
 
     #[test]
@@ -142,10 +142,10 @@ mod tests {
 
         set_filter_fn(context.as_raw_ctx_ptr());
 
-        assert_eq!(context.args_count(), 3);
-        assert_eq!(context.cmd_get_try_as_str(), Ok("SET"));
-        assert_eq!(context.arg_get_try_as_str(1), Ok("new_key"));
-        assert_eq!(context.arg_get_try_as_str(2), Ok("new_value"));
+        assert_eq!(
+            context.args(),
+            vec![b"SET".as_slice(), b"new_key", b"new_value"]
+        );
     }
 
     #[test]
@@ -155,9 +155,7 @@ mod tests {
 
         set_filter_fn(context.as_raw_ctx_ptr());
 
-        assert_eq!(context.args_count(), 2);
-        assert_eq!(context.cmd_get_try_as_str(), Ok("SET"));
-        assert_eq!(context.arg_get_try_as_str(1), Ok("key"));
+        assert_eq!(context.args(), vec![b"SET".as_slice(), b"key"]);
     }
 
     #[test]
@@ -167,9 +165,6 @@ mod tests {
 
         set_filter_fn(context.as_raw_ctx_ptr());
 
-        assert_eq!(context.args_count(), 3);
-        assert_eq!(context.cmd_get_try_as_str(), Ok("GET"));
-        assert_eq!(context.arg_get_try_as_str(1), Ok("key"));
-        assert_eq!(context.arg_get_try_as_str(2), Ok("value"));
+        assert_eq!(context.args(), vec![b"GET".as_slice(), b"key", b"value"]);
     }
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -34,16 +34,16 @@ valkey_module! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use valkey_module::test_shims::create_test_args;
     use valkey_module::ValkeyValue;
-
-    fn test_args(args: &[&str]) -> Vec<ValkeyString> {
-        args.iter().map(|arg| ValkeyString::test(*arg)).collect()
-    }
 
     #[test]
     fn multiplies_integer_arguments() {
-        let result = hello_mul(&Context::dummy(), test_args(&["hello.mul", "2", "3", "4"]))
-            .expect("valid integers should be multiplied");
+        let result = hello_mul(
+            &Context::dummy(),
+            create_test_args(&["hello.mul", "2", "3", "4"]),
+        )
+        .expect("valid integers should be multiplied");
 
         assert_eq!(
             result,
@@ -58,14 +58,17 @@ mod tests {
 
     #[test]
     fn rejects_missing_arguments() {
-        let result = hello_mul(&Context::dummy(), test_args(&["hello.mul"]));
+        let result = hello_mul(&Context::dummy(), create_test_args(&["hello.mul"]));
 
         assert!(matches!(result, Err(ValkeyError::WrongArity)));
     }
 
     #[test]
     fn rejects_non_integer_arguments() {
-        let result = hello_mul(&Context::dummy(), test_args(&["hello.mul", "2", "invalid"]));
+        let result = hello_mul(
+            &Context::dummy(),
+            create_test_args(&["hello.mul", "2", "invalid"]),
+        );
 
         assert!(matches!(result, Err(ValkeyError::Str(_))));
     }

--- a/examples/subcmd.rs
+++ b/examples/subcmd.rs
@@ -125,22 +125,22 @@ valkey_module! {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn test_args(args: &[&str]) -> Vec<ValkeyString> {
-        args.iter().map(|arg| ValkeyString::test(*arg)).collect()
-    }
+    use valkey_module::test_shims::create_test_args;
 
     #[test]
     fn routes_nested_subcommands_case_insensitively() {
-        let result = cmd1(&Context::dummy(), test_args(&["cmd1", "S1", "s1", "S1"]))
-            .expect("nested subcommand should succeed");
+        let result = cmd1(
+            &Context::dummy(),
+            create_test_args(&["cmd1", "S1", "s1", "S1"]),
+        )
+        .expect("nested subcommand should succeed");
 
         assert_eq!(result, ValkeyValue::BulkString("sub111".into()));
     }
 
     #[test]
     fn rejects_unknown_top_level_subcommand() {
-        let result = cmd1(&Context::dummy(), test_args(&["cmd1", "unknown"]));
+        let result = cmd1(&Context::dummy(), create_test_args(&["cmd1", "unknown"]));
 
         assert!(matches!(
             result,
@@ -150,8 +150,11 @@ mod tests {
 
     #[test]
     fn filters_info_to_requested_section() {
-        let result = cmd1(&Context::dummy(), test_args(&["cmd1", "info", "integer"]))
-            .expect("known info section should succeed");
+        let result = cmd1(
+            &Context::dummy(),
+            create_test_args(&["cmd1", "info", "integer"]),
+        )
+        .expect("known info section should succeed");
 
         assert_eq!(
             result,

--- a/src/test-shims/command_filter_ctx.rs
+++ b/src/test-shims/command_filter_ctx.rs
@@ -97,6 +97,14 @@ impl TestCommandFilterCtx {
         self
     }
 
+    /// Returns the configured arguments in position order without UTF-8 conversion.
+    #[must_use]
+    pub fn args(&self) -> Vec<&[u8]> {
+        (0..self.data.args_count)
+            .filter_map(|position| self.data.args.get(&position).map(ValkeyString::as_slice))
+            .collect()
+    }
+
     /// Configures the value returned by [`CommandFilterCtx::args_count`].
     pub fn expect_args_count(&mut self, args_count: libc::c_int) -> &mut Self {
         self.data.args_count = args_count;
@@ -332,6 +340,18 @@ mod tests {
         assert_eq!(context.cmd_get_try_as_str(), Ok("SET"));
         assert_eq!(context.arg_get_try_as_str(1), Ok("key"));
         assert_eq!(context.arg_get_try_as_str(2), Ok("value"));
+    }
+
+    #[test]
+    fn returns_mutated_arguments_in_order_without_utf8_conversion() {
+        let mut context = CommandFilterCtx::test();
+        context.expect_args(&[b"SET".as_slice(), b"\0\xff", b"old"]);
+
+        context.arg_replace(2, "new");
+        context.arg_insert(3, "tail");
+        context.arg_delete(2);
+
+        assert_eq!(context.args(), vec![b"SET".as_slice(), b"\0\xff", b"tail"]);
     }
 
     #[test]

--- a/src/test-shims/command_filter_ctx.rs
+++ b/src/test-shims/command_filter_ctx.rs
@@ -83,6 +83,20 @@ impl TestCommandFilterCtx {
         (self.data.as_mut() as *mut CommandFilterData).cast()
     }
 
+    /// Configures the complete argument list and its reported count.
+    pub fn expect_args<T: AsRef<[u8]>>(&mut self, args: &[T]) -> &mut Self {
+        let args_count = libc::c_int::try_from(args.len())
+            .expect("test command-filter argument count must fit in c_int");
+        self.data.args_count = args_count;
+        self.data.args.clear();
+        self.data.args.extend(
+            (0..args_count)
+                .zip(args)
+                .map(|(position, argument)| (position, ValkeyString::test(argument.as_ref()))),
+        );
+        self
+    }
+
     /// Configures the value returned by [`CommandFilterCtx::args_count`].
     pub fn expect_args_count(&mut self, args_count: libc::c_int) -> &mut Self {
         self.data.args_count = args_count;
@@ -306,6 +320,18 @@ mod tests {
         context.expect_args_count(1).expect_args_count(4);
 
         assert_eq!(context.args_count(), 4);
+    }
+
+    #[test]
+    fn configures_all_arguments_and_count() {
+        let mut context = CommandFilterCtx::test();
+
+        context.expect_args(&["SET", "key", "value"]);
+
+        assert_eq!(context.args_count(), 3);
+        assert_eq!(context.cmd_get_try_as_str(), Ok("SET"));
+        assert_eq!(context.arg_get_try_as_str(1), Ok("key"));
+        assert_eq!(context.arg_get_try_as_str(2), Ok("value"));
     }
 
     #[test]

--- a/src/test-shims/mod.rs
+++ b/src/test-shims/mod.rs
@@ -19,6 +19,13 @@ use std::sync::Once;
 
 static INIT: Once = Once::new();
 
+/// Creates owned, binary-safe test command arguments from byte-like values.
+pub fn create_test_args<T: AsRef<[u8]>>(args: &[T]) -> Vec<crate::ValkeyString> {
+    args.iter()
+        .map(|arg| crate::ValkeyString::test(arg.as_ref()))
+        .collect()
+}
+
 fn setup_test_shims() {
     INIT.call_once(|| {
         assert!(
@@ -41,5 +48,20 @@ fn real_valkey_api_is_initialized() -> bool {
     unsafe {
         addr_of!(raw::RedisModule_GetApi).read().is_some()
             || addr_of!(raw::ValkeyModule_GetApi).read().is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creates_binary_safe_test_arguments() {
+        let input = [b"text".as_slice(), b"\0\xff".as_slice()];
+
+        let args = create_test_args(&input);
+
+        assert_eq!(args[0].as_slice(), b"text");
+        assert_eq!(args[1].as_slice(), b"\0\xff");
     }
 }


### PR DESCRIPTION
• - Added generic, binary-safe create_test_args helper function
  - Added TestCommandFilterCtx::expect_args() and ::args() helper functions
  - Refactored the hello and subcmd unit tests to use the shared create_test_args() helper.
  - Simplified the filter1 tests to use expert_args() and args()
  - Updated the README with usage examples and documentation for the new test helpers.